### PR TITLE
'DOTS' curves implementation

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -207,13 +207,13 @@ Done, awaiting Blog Update:
   - [A Practical and Controllable Hair and Fur Model for Production Path Tracing [Chiang et al. 2016]](https://sci-hub.sg/storage/2024/5766/a1c3a0a1d0aeccafa669d9c39f33341d/chiang2016.pdf)
   - Impl based again based on PBRT's https://www.pbr-book.org/4ed/Reflection_Models/Scattering_from_Hair
 - [x] Curve (hair, fur) rendering
-  - Blender `POLY` splines ↔ standard glTF `LINES` + `_RADIUS` + `TEXCOORD_0` (via https://github.com/mos9527/Foundation-Blender-IO)
-  - Import bakes Disjoint Orthogonal Triangle Strips (DOTS)
+  - https://github.com/mos9527/Foundation/pull/15
+  - Blender `POLY` splines as standard glTF `LINES` + `_RADIUS` + `TEXCOORD_0` (via https://github.com/mos9527/Foundation-Blender-IO)
+  - Import bakes Disjoint Orthogonal Triangle Strips (DOTS)    
     - See also [Path-Traced Hair Rendering in Indiana Jones and the Great Circle](https://vulkan.org/user/pages/09.events/vulkanised-2026/1145-Jiho-Choi-NVIDIA%201.pdf)
     - https://github.com/NVIDIA-RTX/RTXCR is used as a reference implementation
-  - Hardware triangle BLAS traversal; shading reconstructs a tapered-cone normal / hair `h` after the hit
-  - Raster draws the same DOTS triangles via a cull-disabled indexed MDI pass (alongside skinned meshes)
   - [ ] TODO Possiblity to bind strands to mesh - therefore texturing it?
+  - [ ] TODO Support NV [LSS](https://developer.nvidia.com/blog/render-path-traced-hair-in-real-time-with-nvidia-geforce-rtx-50-series-gpus/)?
 - [x] Path Traced Skin BSSRDF
   - Disney BSSRDF from [PBRTv3](https://github.com/mmp/pbrt-v3/blob/master/src/materials/disney.cpp)
   - Uniformly selects exitance point on scattered path via AnyHit + reservoir sampling
@@ -225,6 +225,7 @@ Done, awaiting Blog Update:
     - Conversion to small disk lights is feasible, or another O(N) loop to evaluate all of those inline w/o going through scene BVH
     - Not worth it nonetheless. This is merely brute-forcing.
 - [x] Light BVH sampling for scene lights
+  - https://github.com/mos9527/Foundation/pull/14
   - https://fileadmin.cs.lth.se/graphics/research/papers/2019/dyn_manylight/MPC19_presentation.pdf, implementation referencing https://github.com/NVIDIAGameWorks/Falcor
   - Also PBRTv4's implementation in https://www.pbr-book.org/4ed/Light_Sources/Light_Sampling
 - [x] Importance sampling Infinite Image Lights

--- a/DOCS.md
+++ b/DOCS.md
@@ -207,9 +207,12 @@ Done, awaiting Blog Update:
   - [A Practical and Controllable Hair and Fur Model for Production Path Tracing [Chiang et al. 2016]](https://sci-hub.sg/storage/2024/5766/a1c3a0a1d0aeccafa669d9c39f33341d/chiang2016.pdf)
   - Impl based again based on PBRT's https://www.pbr-book.org/4ed/Reflection_Models/Scattering_from_Hair
 - [x] Curve (hair, fur) rendering
-  - Beizer Segments via [De Casteljau](https://zh.wikipedia.org/wiki/%E5%BE%B7%E5%8D%A1%E6%96%AF%E7%89%B9%E9%87%8C%E5%A5%A5%E7%AE%97%E6%B3%95), a la PBRT's [Curves](https://www.pbr-book.org/4ed/Shapes/Curves#Curve)
-  - Intersected as flat cross-sections with TBN that 'makes it look like a swept cylinder'
-  - Procedurally traced, data exchange done via our own Blender IO (https://github.com/mos9527/Foundation-Blender-IO)
+  - Blender `POLY` splines ↔ standard glTF `LINES` + `_RADIUS` + `TEXCOORD_0` (via https://github.com/mos9527/Foundation-Blender-IO)
+  - Import bakes Disjoint Orthogonal Triangle Strips (DOTS)
+    - See also [Path-Traced Hair Rendering in Indiana Jones and the Great Circle](https://vulkan.org/user/pages/09.events/vulkanised-2026/1145-Jiho-Choi-NVIDIA%201.pdf)
+    - https://github.com/NVIDIA-RTX/RTXCR is used as a reference implementation
+  - Hardware triangle BLAS traversal; shading reconstructs a tapered-cone normal / hair `h` after the hit
+  - Raster draws the same DOTS triangles via a cull-disabled indexed MDI pass (alongside skinned meshes)
   - [ ] TODO Possiblity to bind strands to mesh - therefore texturing it?
 - [x] Path Traced Skin BSSRDF
   - Disney BSSRDF from [PBRTv3](https://github.com/mmp/pbrt-v3/blob/master/src/materials/disney.cpp)

--- a/Editor/EditorScene.cpp
+++ b/Editor/EditorScene.cpp
@@ -455,9 +455,8 @@ static GPUScene* CreateGPUScene(FImportedScene const& scene, size_t& outBudgetBy
 {
     auto estimatedBudget = CalculateSceneGPUDesc(scene, GContext->device->GetCapabilities());
     LOG(Editor, LogDebug,
-        "Estimated GPUScene budget: primitive {} MB, curve AABB {} MB, instances {}, TLAS instances {}, materials {}, lights {}, textures {}",
+        "Estimated GPUScene budget: primitive {} MB, instances {}, TLAS instances {}, materials {}, lights {}, textures {}",
         estimatedBudget.primitiveBudget / (1u << 20),
-        estimatedBudget.curveAABBBudget / (1u << 20),
         estimatedBudget.instanceBudget,
         estimatedBudget.tlasInstanceBudget,
         estimatedBudget.materialBudget,

--- a/Editor/Scene/Curve.hpp
+++ b/Editor/Scene/Curve.hpp
@@ -1,23 +1,20 @@
 #pragma once
 #include <Renderer/Curve.hpp>
 
-enum class FCurveBasis : uint32_t
+// One tapered line segment prior to DOTS bake (from glTF LINES + _RADIUS).
+struct FImportedCurveSegment
 {
-    Linear = 0,
-    Bezier = 1,
-    BSpline = 2,
-    CatmullRom = 3,
+    float3 p0;
+    float r0;
+    float3 p1;
+    float r1;
+    float u0;
+    float u1;
 };
-enum class FCurveRenderMode : uint32_t
-{
-    Capsule = 0,
-};
+
 struct FImportedCurve
 {
-    Vector<FCurvePoint> points;
-    Vector<uint32_t> curveVertexCounts;
-    FCurveBasis basis{FCurveBasis::Linear};
-    FCurveRenderMode renderMode{FCurveRenderMode::Capsule};
+    Vector<FImportedCurveSegment> segments;
 
-    FImportedCurve(Allocator* alloc) : points(alloc), curveVertexCounts(alloc) {}
+    FImportedCurve(Allocator* alloc) : segments(alloc) {}
 };

--- a/Editor/Scene/Scene.cpp
+++ b/Editor/Scene/Scene.cpp
@@ -49,16 +49,80 @@ FSerializedBounds BuildMeshBounds(FImportedMesh const& mesh)
 
 FSerializedBounds BuildCurveBounds(FImportedCurve const& curve)
 {
-    if (curve.points.empty())
+    if (curve.segments.empty())
         return {};
 
     FSerializedBounds bounds = FSerializedBounds::Empty();
-    for (FCurvePoint const& point : curve.points)
+    for (FImportedCurveSegment const& segment : curve.segments)
     {
-        bounds += point.position - float3(point.radius);
-        bounds += point.position + float3(point.radius);
+        bounds += segment.p0 - float3(segment.r0);
+        bounds += segment.p0 + float3(segment.r0);
+        bounds += segment.p1 - float3(segment.r1);
+        bounds += segment.p1 + float3(segment.r1);
     }
     return bounds;
+}
+
+const cgltf_accessor* FindCustomAttribute(const cgltf_primitive* prim, char const* name)
+{
+    for (size_t i = 0; i < prim->attributes_count; ++i)
+    {
+        cgltf_attribute const& attr = prim->attributes[i];
+        if (attr.type == cgltf_attribute_type_custom && attr.name && std::strcmp(attr.name, name) == 0)
+            return attr.data;
+    }
+    return nullptr;
+}
+
+bool IsLineCurvePrimitive(const cgltf_primitive* prim)
+{
+    if (!prim)
+        return false;
+    if (prim->type != cgltf_primitive_type_lines && prim->type != cgltf_primitive_type_line_strip &&
+        prim->type != cgltf_primitive_type_line_loop)
+        return false;
+    return FindCustomAttribute(prim, "_RADIUS") != nullptr;
+}
+
+// Volume-compensated DOTS radius scale: 1 / (sin(pi/4) / (pi/4)).
+static constexpr float kDOTSRadiusScale = 1.1107207345f;
+
+void EmitDOTSLeaf(FImportedCurveSegment const& segment, Vector<FCurveDOTSVertex>& vertices, Vector<uint32_t>& indices,
+                  Vector<FCurveLeaf>& leaves)
+{
+    float3 axis = segment.p1 - segment.p0;
+    float len2 = dot(axis, axis);
+    if (len2 <= 1e-12f || (segment.r0 <= 0.0f && segment.r1 <= 0.0f))
+        return;
+
+    float3 fwd = axis * (1.0f / std::sqrt(len2));
+    float3 s, t;
+    CoordinateSystem(fwd, s, t);
+    float sr0 = segment.r0 * kDOTSRadiusScale;
+    float sr1 = segment.r1 * kDOTSRadiusScale;
+
+    leaves.push_back(FCurveLeaf{.p0 = segment.p0,
+                                .r0 = segment.r0,
+                                .p1 = segment.p1,
+                                .r1 = segment.r1,
+                                .u0 = segment.u0,
+                                .u1 = segment.u1});
+
+    float3 axes[2] = {s, t};
+    for (float3 const& side : axes)
+    {
+        uint32_t base = static_cast<uint32_t>(vertices.size());
+        vertices.push_back(FCurveDOTSVertex{.position = segment.p0 + side * sr0, .pad = 0.0f});
+        vertices.push_back(FCurveDOTSVertex{.position = segment.p1 + side * sr1, .pad = 0.0f});
+        vertices.push_back(FCurveDOTSVertex{.position = segment.p1 - side * sr1, .pad = 0.0f});
+        vertices.push_back(FCurveDOTSVertex{.position = segment.p0 - side * sr0, .pad = 0.0f});
+        indices.push_back(base + 0);
+        indices.push_back(base + 1);
+        indices.push_back(base + 2);
+        indices.push_back(base + 0);
+        indices.push_back(base + 2);
+        indices.push_back(base + 3);
+    }
 }
 
 StringView Trim(StringView value)
@@ -513,10 +577,13 @@ void ValidateSceneTables(FSceneHeader const& header, FSceneTables const& tables)
 
     for (auto const& curve : tables.curves)
     {
-        ValidateBlobArray<FCurvePoint>(header, curve.points, "curve.points");
-        ValidateBlobArray<FSerializedCurveSegment>(header, curve.segments, "curve.segments");
-        ValidateBlobArray<FSerializedCurveAABB>(header, curve.aabbs, "curve.aabbs");
-        CHECK_MSG(curve.segments.count == curve.aabbs.count, "FScene curve AABB count mismatch");
+        ValidateBlobArray<FCurveDOTSVertex>(header, curve.vertices, "curve.vertices");
+        ValidateBlobArray<uint32_t>(header, curve.indices, "curve.indices");
+        ValidateBlobArray<FCurveLeaf>(header, curve.leaves, "curve.leaves");
+        CHECK_MSG(curve.indices.count % 3 == 0, "FScene curve index count must be a multiple of 3");
+        CHECK_MSG(curve.indices.count == curve.leaves.count * 12,
+                  "FScene curve DOTS index/leaf count mismatch: {} indices for {} leaves", curve.indices.count,
+                  curve.leaves.count);
     }
 
     for (auto const& texture : tables.textures)
@@ -752,60 +819,92 @@ Optional<FTexture> LoadGLTFTexture(cgltf_texture* texture, StringView scenePath,
     return {};
 }
 
-FCurveBasis LoadGLTFCurveBasis(cgltf_curve_basis basis)
-{
-    switch (basis)
-    {
-    case cgltf_curve_basis_bezier:
-        return FCurveBasis::Bezier;
-    case cgltf_curve_basis_bspline:
-        return FCurveBasis::BSpline;
-    case cgltf_curve_basis_catmull_rom:
-        return FCurveBasis::CatmullRom;
-    case cgltf_curve_basis_linear:
-    default:
-        return FCurveBasis::Linear;
-    }
-}
-
-void LoadGLTFCurve(const cgltf_data* data, const cgltf_curve* src, FImportedCurve& curve, Allocator* scratchAlloc)
+void LoadGLTFLineCurve(const cgltf_primitive* prim, FImportedCurve& curve, Allocator* scratchAlloc)
 {
     CHECK(scratchAlloc != nullptr);
-    CHECK(src->points);
-    CHECK(src->curve_vertex_counts);
-    CHECK(src->points->type == cgltf_type_vec4);
-    CHECK(src->points->component_type == cgltf_component_type_r_32f);
-    CHECK(src->curve_vertex_counts->type == cgltf_type_scalar);
+    CHECK(IsLineCurvePrimitive(prim));
 
-    curve.basis = LoadGLTFCurveBasis(src->basis);
-    CHECK_MSG(curve.basis == FCurveBasis::Bezier, "EXT_foundation_curves import currently supports only Bezier curves");
-    curve.renderMode = FCurveRenderMode::Capsule;
+    auto* positionAcc = cgltf_find_accessor(prim, cgltf_attribute_type_position, 0);
+    auto* radiusAcc = FindCustomAttribute(prim, "_RADIUS");
+    auto* texcoordAcc = cgltf_find_accessor(prim, cgltf_attribute_type_texcoord, 0);
+    CHECK_MSG(positionAcc, "Curve LINES primitive missing POSITION");
+    CHECK_MSG(radiusAcc, "Curve LINES primitive missing _RADIUS");
+    CHECK_MSG(positionAcc->type == cgltf_type_vec3, "Curve POSITION must be VEC3");
+    CHECK_MSG(radiusAcc->type == cgltf_type_scalar, "Curve _RADIUS must be SCALAR");
 
-    size_t pointCount = src->points->count;
-    Vector<float> unpack(pointCount * 4, scratchAlloc);
-    cgltf_accessor_unpack_floats(src->points, unpack.data(), unpack.size());
-    curve.points.resize(pointCount);
-    for (size_t i = 0; i < pointCount; i++)
+    size_t pointCount = positionAcc->count;
+    CHECK_MSG(radiusAcc->count == pointCount, "Curve _RADIUS count ({}) != POSITION count ({})", radiusAcc->count,
+              pointCount);
+
+    Vector<float> positions(pointCount * 3, scratchAlloc);
+    Vector<float> radii(pointCount, scratchAlloc);
+    Vector<float> us(pointCount, 0.0f, scratchAlloc);
+    cgltf_accessor_unpack_floats(positionAcc, positions.data(), positions.size());
+    cgltf_accessor_unpack_floats(radiusAcc, radii.data(), radii.size());
+    if (texcoordAcc)
     {
-        curve.points[i] = FCurvePoint{
-            .position = {unpack[i * 4 + 0], unpack[i * 4 + 1], unpack[i * 4 + 2]},
-            .radius = unpack[i * 4 + 3],
-        };
+        CHECK_MSG(texcoordAcc->count == pointCount, "Curve TEXCOORD_0 count mismatch");
+        Vector<float> uvs(pointCount * 2, scratchAlloc);
+        cgltf_accessor_unpack_floats(texcoordAcc, uvs.data(), uvs.size());
+        for (size_t i = 0; i < pointCount; ++i)
+            us[i] = uvs[i * 2];
     }
 
-    curve.curveVertexCounts.resize(src->curve_vertex_counts->count);
-    uint64_t referencedPoints = 0;
-    for (size_t i = 0; i < src->curve_vertex_counts->count; i++)
+    auto EmitSegment = [&](uint32_t i0, uint32_t i1)
     {
-        cgltf_uint count = 0;
-        CHECK(cgltf_accessor_read_uint(src->curve_vertex_counts, i, &count, 1));
-        curve.curveVertexCounts[i] = count;
-        CHECK_MSG(count >= 4 && (count - 1) % 3 == 0,
-                  "Bezier curve strands must contain 3n + 1 controls, got {}", count);
-        referencedPoints += count;
+        CHECK_MSG(i0 < pointCount && i1 < pointCount, "Curve line index out of range");
+        float3 p0{positions[i0 * 3 + 0], positions[i0 * 3 + 1], positions[i0 * 3 + 2]};
+        float3 p1{positions[i1 * 3 + 0], positions[i1 * 3 + 1], positions[i1 * 3 + 2]};
+        if (dot(p1 - p0, p1 - p0) <= 1e-12f)
+            return;
+        curve.segments.push_back(FImportedCurveSegment{.p0 = p0,
+                                                       .r0 = std::max(radii[i0], 0.0f),
+                                                       .p1 = p1,
+                                                       .r1 = std::max(radii[i1], 0.0f),
+                                                       .u0 = us[i0],
+                                                       .u1 = us[i1]});
+    };
+
+    if (prim->type == cgltf_primitive_type_lines)
+    {
+        if (prim->indices)
+        {
+            size_t indexCount = prim->indices->count;
+            CHECK_MSG(indexCount % 2 == 0, "Indexed LINES index count must be even");
+            Vector<uint32_t> indices(indexCount, scratchAlloc);
+            cgltf_accessor_unpack_indices(prim->indices, indices.data(), sizeof(uint32_t), indexCount);
+            for (size_t i = 0; i + 1 < indexCount; i += 2)
+                EmitSegment(indices[i], indices[i + 1]);
+        }
+        else
+        {
+            CHECK_MSG(pointCount % 2 == 0, "Non-indexed LINES vertex count must be even");
+            for (size_t i = 0; i + 1 < pointCount; i += 2)
+                EmitSegment(static_cast<uint32_t>(i), static_cast<uint32_t>(i + 1));
+        }
     }
-    CHECK_MSG(referencedPoints == pointCount, "Curve strands reference {} points, but points accessor stores {}",
-              referencedPoints, pointCount);
+    else
+    {
+        Vector<uint32_t> order(scratchAlloc);
+        if (prim->indices)
+        {
+            size_t indexCount = prim->indices->count;
+            order.resize(indexCount);
+            cgltf_accessor_unpack_indices(prim->indices, order.data(), sizeof(uint32_t), indexCount);
+        }
+        else
+        {
+            order.resize(pointCount);
+            std::iota(order.begin(), order.end(), 0u);
+        }
+        CHECK_MSG(order.size() >= 2, "LINE_STRIP/LINE_LOOP requires at least two vertices");
+        for (size_t i = 0; i + 1 < order.size(); ++i)
+            EmitSegment(order[i], order[i + 1]);
+        if (prim->type == cgltf_primitive_type_line_loop)
+            EmitSegment(order.back(), order.front());
+    }
+
+    CHECK_MSG(!curve.segments.empty(), "Curve LINES primitive produced no valid segments");
 }
 
 size_t GetSceneWorkerCount()
@@ -1537,112 +1636,121 @@ void BuildGLTFSerializedScene(StringView path, FImportedScene& scene, Allocator*
         }
     }
 
-    /* Meshes */
-    size_t numSubmeshes = 0;
+    /* Meshes (triangles) and curves (LINES + _RADIUS) */
+    struct MeshPrimitiveResource
+    {
+        FInstanceType type{FInstanceType::Mesh};
+        uint32_t index{~0u}; // into meshes or curves table
+    };
+    size_t numTrianglePrimitives = 0;
+    size_t numCurvePrimitives = 0;
     for (size_t i = 0; i < data->meshes_count; i++)
-        numSubmeshes += data->meshes[i].primitives_count;
-    scene.mTables.meshes.reserve(numSubmeshes);
-    for (size_t i = 0; i < numSubmeshes; i++)
-        scene.mTables.meshes.emplace_back(scratchAlloc);
-    for (size_t i = 0; i < numSubmeshes; i++)
     {
-        scene.mTables.meshes[i].id = FUUID::Generate();
+        for (size_t p = 0; p < data->meshes[i].primitives_count; ++p)
+        {
+            auto* sub = data->meshes[i].primitives + p;
+            if (sub->type == cgltf_primitive_type_triangles)
+                ++numTrianglePrimitives;
+            else if (IsLineCurvePrimitive(sub))
+                ++numCurvePrimitives;
+            else
+                CHECK_MSG(false, "Unsupported glTF primitive mode {} (only triangles and LINES+_RADIUS curves)",
+                          static_cast<int>(sub->type));
+        }
     }
+
+    scene.mTables.meshes.reserve(numTrianglePrimitives);
+    for (size_t i = 0; i < numTrianglePrimitives; i++)
+        scene.mTables.meshes.emplace_back(scratchAlloc);
+    for (size_t i = 0; i < numTrianglePrimitives; i++)
+        scene.mTables.meshes[i].id = FUUID::Generate();
+
+    scene.mTables.curves.resize(numCurvePrimitives);
+    for (size_t i = 0; i < numCurvePrimitives; i++)
+        scene.mTables.curves[i].id = FUUID::Generate();
+
     Vector<FResourceBlobJobs> meshBlobJobs(scratchAlloc);
-    meshBlobJobs.reserve(numSubmeshes);
-    for (size_t i = 0; i < numSubmeshes; i++)
+    meshBlobJobs.reserve(numTrianglePrimitives);
+    for (size_t i = 0; i < numTrianglePrimitives; i++)
         meshBlobJobs.emplace_back(scratchAlloc);
-    Vector<Pair<size_t, size_t>> submeshIndices(scratchAlloc);
-    submeshIndices.reserve(data->meshes_count);
+    Vector<FResourceBlobJobs> curveBlobJobs(scratchAlloc);
+    curveBlobJobs.reserve(numCurvePrimitives);
+    for (size_t i = 0; i < numCurvePrimitives; i++)
+        curveBlobJobs.emplace_back(scratchAlloc);
+
+    Vector<Vector<MeshPrimitiveResource>> meshPrimitiveResources(scratchAlloc);
+    meshPrimitiveResources.reserve(data->meshes_count);
+    for (size_t i = 0; i < data->meshes_count; ++i)
+        meshPrimitiveResources.push_back(Vector<MeshPrimitiveResource>(scratchAlloc));
+
     uint32_t nextSubmesh = 0;
-    if (numSubmeshes != 0)
+    uint32_t nextCurve = 0;
+    size_t totalPrimitives = numTrianglePrimitives + numCurvePrimitives;
+    if (totalPrimitives != 0)
     {
-        ThreadPool pool(GetSceneWorkerCount(), GetSceneTaskQueueSize(numSubmeshes), scratchAlloc, "SceneMesh");
+        ThreadPool pool(GetSceneWorkerCount(), GetSceneTaskQueueSize(totalPrimitives), scratchAlloc, "SceneGeo");
         Vector<Future<void>> futures(scratchAlloc);
-        futures.reserve(numSubmeshes);
+        futures.reserve(totalPrimitives);
         for (size_t i = 0; i < data->meshes_count; i++)
         {
             auto& mesh = data->meshes[i];
             int32_t skinIndex = meshToSkin[i];
             bool const morphAnimated = meshMorphAnimated[i] != 0;
             const Vector<uint16_t>* remap = skinIndex >= 0 ? &skinRemap[skinIndex] : nullptr;
-            auto& [mmin, mmax] = submeshIndices.emplace_back(nextSubmesh, nextSubmesh);
+            meshPrimitiveResources[i].reserve(mesh.primitives_count);
             for (size_t p = 0; p < mesh.primitives_count; p++)
             {
                 auto* sub = mesh.primitives + p;
-                CHECK(sub->type == cgltf_primitive_type_triangles);
-                uint32_t meshIndex = nextSubmesh++;
-                futures.push_back(pool.Push(
-                    [&, meshIndex, sub, skinIndex, morphAnimated, remap]
-                    {
-                        FImportedMesh submesh = LoadGLTFSubmesh(sub, scratchAlloc, remap, morphAnimated);
-                        // Deforming meshes (skinned or morph-animated) take the dynamic vertex/index
-                        // path: skip vertex reordering (which would desync the per-vertex binding /
-                        // morph deltas) and the DAG/meshlet build.
-                        bool const dynamic = !submesh.skin.empty() || morphAnimated;
-                        if (!dynamic)
+                if (sub->type == cgltf_primitive_type_triangles)
+                {
+                    uint32_t meshIndex = nextSubmesh++;
+                    meshPrimitiveResources[i].push_back(
+                        MeshPrimitiveResource{.type = FInstanceType::Mesh, .index = meshIndex});
+                    futures.push_back(pool.Push(
+                        [&, meshIndex, sub, skinIndex, morphAnimated, remap]
                         {
-                            LOG(Meshopt, LogInfo, "Optimizing submesh {}, vtx: {}, idx: {}", meshIndex,
-                                submesh.vertices.size(), submesh.lods[0].indices.size());
-                            submesh.Optimize();
-                            submesh.ClusterizeDAG();
-                            LOG(Meshopt, LogInfo, "Optimized {}", meshIndex);
-                        }
-                        submesh.Quantize();
-                        BuildMeshBlobJobs(scene.mTables.meshes[meshIndex], meshBlobJobs[meshIndex].jobs, submesh,
-                                          submesh.skin.empty() ? kNilUUID : skinSkeletonIds[skinIndex]);
-                    }));
+                            FImportedMesh submesh = LoadGLTFSubmesh(sub, scratchAlloc, remap, morphAnimated);
+                            bool const dynamic = !submesh.skin.empty() || morphAnimated;
+                            if (!dynamic)
+                            {
+                                LOG(Meshopt, LogInfo, "Optimizing submesh {}, vtx: {}, idx: {}", meshIndex,
+                                    submesh.vertices.size(), submesh.lods[0].indices.size());
+                                submesh.Optimize();
+                                submesh.ClusterizeDAG();
+                                LOG(Meshopt, LogInfo, "Optimized {}", meshIndex);
+                            }
+                            submesh.Quantize();
+                            BuildMeshBlobJobs(scene.mTables.meshes[meshIndex], meshBlobJobs[meshIndex].jobs, submesh,
+                                              submesh.skin.empty() ? kNilUUID : skinSkeletonIds[skinIndex]);
+                        }));
+                }
+                else
+                {
+                    uint32_t curveIndex = nextCurve++;
+                    FUUID curveId = scene.mTables.curves[curveIndex].id;
+                    meshPrimitiveResources[i].push_back(
+                        MeshPrimitiveResource{.type = FInstanceType::Curve, .index = curveIndex});
+                    futures.push_back(pool.Push(
+                        [&, curveIndex, curveId, sub]
+                        {
+                            FImportedCurve curve(scratchAlloc);
+                            LoadGLTFLineCurve(sub, curve, scratchAlloc);
+                            BuildCurveBlobJobs(scene.mTables.curves[curveIndex], curveBlobJobs[curveIndex].jobs, curve);
+                            scene.mTables.curves[curveIndex].id = curveId;
+                        }));
+                }
             }
-            mmax = nextSubmesh;
         }
         pool.Join();
         for (Future<void>& future : futures)
             future.get();
         for (FResourceBlobJobs& jobs : meshBlobJobs)
             AppendResourceBlobJobs(blobJobs, jobs);
-    }
-    else
-    {
-        for (size_t i = 0; i < data->meshes_count; i++)
-            submeshIndices.emplace_back(nextSubmesh, nextSubmesh);
-    }
-    CHECK_MSG(nextSubmesh == numSubmeshes, "Serialized mesh count mismatch");
-
-    /* Curves */
-    scene.mTables.curves.resize(data->curves_count);
-    Vector<FUUID> curveIds(data->curves_count, kNilUUID, scratchAlloc);
-    for (size_t i = 0; i < data->curves_count; i++)
-    {
-        curveIds[i] = FUUID::Generate();
-        scene.mTables.curves[i].id = curveIds[i];
-    }
-    Vector<FResourceBlobJobs> curveBlobJobs(scratchAlloc);
-    curveBlobJobs.reserve(data->curves_count);
-    for (size_t i = 0; i < data->curves_count; i++)
-        curveBlobJobs.emplace_back(scratchAlloc);
-    if (data->curves_count != 0)
-    {
-        ThreadPool pool(GetSceneWorkerCount(), GetSceneTaskQueueSize(data->curves_count), scratchAlloc, "SceneCurve");
-        Vector<Future<void>> futures(scratchAlloc);
-        futures.reserve(data->curves_count);
-        for (size_t i = 0; i < data->curves_count; i++)
-        {
-            futures.push_back(pool.Push(
-                [&, i]
-                {
-                    FImportedCurve curve(scratchAlloc);
-                    LoadGLTFCurve(data, &data->curves[i], curve, scratchAlloc);
-                    BuildCurveBlobJobs(scene.mTables.curves[i], curveBlobJobs[i].jobs, curve);
-                    // BuildCurveBlobJobs resets the desc (desc = {}), so re-stamp the id afterwards.
-                    scene.mTables.curves[i].id = curveIds[i];
-                }));
-        }
-        pool.Join();
-        for (Future<void>& future : futures)
-            future.get();
         for (FResourceBlobJobs& jobs : curveBlobJobs)
             AppendResourceBlobJobs(blobJobs, jobs);
     }
+    CHECK_MSG(nextSubmesh == numTrianglePrimitives, "Serialized mesh count mismatch");
+    CHECK_MSG(nextCurve == numCurvePrimitives, "Serialized curve count mismatch");
 
     /* Blob compression and commit */
     Vector<FPreparedBlob> preparedBlobs(scratchAlloc);
@@ -1689,7 +1797,7 @@ void BuildGLTFSerializedScene(StringView path, FImportedScene& scene, Allocator*
             cgltf_node_transform_world(node, reinterpret_cast<float*>(&worldMat));
 
             auto meshIndex = cgltf_mesh_index(data, node->mesh);
-            auto [mmin, mmax] = submeshIndices[meshIndex];
+            auto const& primResources = meshPrimitiveResources[meshIndex];
 
             size_t instCount = 1;
             const cgltf_accessor* tAcc = nullptr;
@@ -1711,7 +1819,6 @@ void BuildGLTFSerializedScene(StringView path, FImportedScene& scene, Allocator*
             }
 
             FInstance instance{};
-            instance.type = FInstanceType::Mesh;
             instance.name = internString(node->name);
             instance.node = NodeJoint(i);
 
@@ -1752,29 +1859,21 @@ void BuildGLTFSerializedScene(StringView path, FImportedScene& scene, Allocator*
                     decompose(instWorld, xform.scale, xform.rotation, xform.transform);
                 }
                 instance.transform = xform;
-                for (size_t j = mmin; j < mmax; j++)
+                for (size_t p = 0; p < primResources.size(); ++p)
                 {
-                    auto* sub = node->mesh->primitives + j - mmin;
+                    auto* sub = node->mesh->primitives + p;
+                    auto const& resource = primResources[p];
                     instance.id = FUUID::Generate();
-                    instance.resource = scene.mTables.meshes[j].id;
+                    instance.type = resource.type;
+                    if (resource.type == FInstanceType::Curve)
+                        instance.resource = scene.mTables.curves[resource.index].id;
+                    else
+                        instance.resource = scene.mTables.meshes[resource.index].id;
                     instance.material = sub->material ? gltfMaterialIds[cgltf_material_index(data, sub->material)]
                                                        : kDefaultMaterialUUID;
                     scene.Add(instance);
                 }
             }
-        }
-        if (node->curve)
-        {
-            FInstance instance{};
-            getTransform(instance.transform);
-            instance.type = FInstanceType::Curve;
-            instance.id = FUUID::Generate();
-            instance.name = internString(node->name);
-            instance.node = NodeJoint(i);
-            instance.resource = curveIds[cgltf_curve_index(data, node->curve)];
-            instance.material = node->curve->material ? gltfMaterialIds[cgltf_material_index(data, node->curve->material)]
-                                                       : kDefaultMaterialUUID;
-            scene.Add(instance);
         }
         if (node->camera)
         {
@@ -1931,11 +2030,13 @@ void BuildGLTFSerializedScene(StringView path, FImportedScene& scene, Allocator*
             size_t const gmesh = cgltf_mesh_index(data, ch->target_node->mesh);
             if (!meshMorphAnimated[gmesh])
                 continue;
-            auto const& [mmin, mmax] = submeshIndices[gmesh];
-            for (size_t idx = mmin; idx < mmax; ++idx)
+            for (auto const& resource : meshPrimitiveResources[gmesh])
             {
+                if (resource.type != FInstanceType::Mesh)
+                    continue;
                 FMorphChannel mc(scratchAlloc);
-                if (BuildMorphChannel(ch, scene.mTables.meshes[idx].id, meshMorphTargetCount[gmesh], mc, clip.duration))
+                if (BuildMorphChannel(ch, scene.mTables.meshes[resource.index].id, meshMorphTargetCount[gmesh], mc,
+                                      clip.duration))
                     clip.morphChannels.push_back(std::move(mc));
             }
         }
@@ -2044,117 +2145,19 @@ void BuildTextureBlobJobs(FSerializedTexture& desc, Vector<FBlobJob>& blobJobs, 
     }
 }
 
-uint32_t CalculateRenderableCurveSegmentCount(FImportedCurve const& curve)
+void BuildDOTSGeometry(FImportedCurve const& curve, Vector<FCurveDOTSVertex>& vertices, Vector<uint32_t>& indices,
+                       Vector<FCurveLeaf>& leaves)
 {
-    uint32_t segmentCount = 0;
-    for (uint32_t count : curve.curveVertexCounts)
-    {
-        switch (curve.basis)
-        {
-        case FCurveBasis::Bezier:
-            CHECK_MSG(count >= 4 && (count - 1) % 3 == 0,
-                      "Bezier curve strands must contain 3n + 1 controls, got {}", count);
-            segmentCount += (count - 1) / 3;
-            break;
-        case FCurveBasis::Linear:
-            segmentCount += count > 1 ? count - 1 : 0;
-            break;
-        default:
-            CHECK_MSG(false, "Unsupported curve basis {}", static_cast<uint32_t>(curve.basis));
-            break;
-        }
-    }
-    return segmentCount;
-}
-
-FSerializedCurveAABB BuildCurveAABB(float3 const& mn, float3 const& mx)
-{
-    return FSerializedCurveAABB{mn.x, mn.y, mn.z, mx.x, mx.y, mx.z};
-}
-
-void BuildCurveGeometry(FImportedCurve const& curve, Span<FSerializedCurveSegment> segments,
-                        Span<FSerializedCurveAABB> aabbs)
-{
-    CHECK_MSG(segments.size() == aabbs.size(), "Curve geometry output size mismatch");
-
-    uint32_t segmentCursor = 0;
-    auto WriteLineSegment = [&](uint32_t p0, uint32_t p1, float u0, float u1)
-    {
-        CHECK(segmentCursor < segments.size());
-        segments[segmentCursor] = FSerializedCurveSegment{.p0 = p0, .p1 = p1, .u0 = u0, .u1 = u1};
-
-        const auto& a = curve.points[p0];
-        const auto& b = curve.points[p1];
-        float radius = std::max(a.radius, b.radius);
-        float3 mn = min(a.position, b.position) - float3(radius);
-        float3 mx = max(a.position, b.position) + float3(radius);
-        aabbs[segmentCursor] = BuildCurveAABB(mn, mx);
-        segmentCursor++;
-    };
-    auto WriteBezierSpan = [&](uint32_t p0, uint32_t p1, float u0, float u1)
-    {
-        CHECK(segmentCursor < segments.size());
-        segments[segmentCursor] = FSerializedCurveSegment{.p0 = p0, .p1 = p1, .u0 = u0, .u1 = u1};
-
-        const auto& a = curve.points[p0];
-        const auto& b = curve.points[p0 + 1];
-        const auto& c = curve.points[p0 + 2];
-        const auto& d = curve.points[p1];
-        float radius = std::max(std::max(a.radius, b.radius), std::max(c.radius, d.radius));
-        float3 mn = min(min(a.position, b.position), min(c.position, d.position)) - float3(radius);
-        float3 mx = max(max(a.position, b.position), max(c.position, d.position)) + float3(radius);
-        aabbs[segmentCursor] = BuildCurveAABB(mn, mx);
-        segmentCursor++;
-    };
-
-    uint32_t pointCursor = 0;
-    for (uint32_t count : curve.curveVertexCounts)
-    {
-        CHECK_MSG(pointCursor + count <= curve.points.size(), "Curve set references more points than it stores");
-        if (count <= 1)
-        {
-            pointCursor += count;
-            continue;
-        }
-
-        switch (curve.basis)
-        {
-        case FCurveBasis::Bezier:
-        {
-            CHECK_MSG(count >= 4 && (count - 1) % 3 == 0,
-                      "Bezier curve strands must contain 3n + 1 controls, got {}", count);
-            uint32_t spanCount = (count - 1) / 3;
-            float invSpanCount = 1.0f / float(spanCount);
-            for (uint32_t i = 0; i < spanCount; ++i)
-            {
-                uint32_t p0 = pointCursor + i * 3;
-                uint32_t p1 = pointCursor + (i + 1) * 3;
-                WriteBezierSpan(p0, p1, float(i) * invSpanCount, float(i + 1) * invSpanCount);
-            }
-            break;
-        }
-        case FCurveBasis::Linear:
-        {
-            float invSegmentCount = 1.0f / float(count - 1);
-            for (uint32_t i = 0; i + 1 < count; ++i)
-            {
-                uint32_t p0 = pointCursor + i;
-                uint32_t p1 = pointCursor + i + 1;
-                WriteLineSegment(p0, p1, float(i) * invSegmentCount, float(i + 1) * invSegmentCount);
-            }
-            break;
-        }
-        default:
-            CHECK_MSG(false, "Unsupported curve basis {}", static_cast<uint32_t>(curve.basis));
-            break;
-        }
-        pointCursor += count;
-    }
-
-    CHECK_MSG(pointCursor == curve.points.size(), "Curve strands reference {} points, but points array stores {}",
-              pointCursor, curve.points.size());
-    CHECK_MSG(segmentCursor == segments.size(), "Curve segment count mismatch: expected {} got {}",
-              segments.size(), segmentCursor);
+    vertices.clear();
+    indices.clear();
+    leaves.clear();
+    vertices.reserve(curve.segments.size() * 8);
+    indices.reserve(curve.segments.size() * 12);
+    leaves.reserve(curve.segments.size());
+    for (FImportedCurveSegment const& segment : curve.segments)
+        EmitDOTSLeaf(segment, vertices, indices, leaves);
+    CHECK_MSG(!leaves.empty(), "DOTS bake produced no leaves");
+    CHECK_MSG(indices.size() == leaves.size() * 12, "DOTS index/leaf count mismatch");
 }
 
 void BuildMeshBlobJobs(FSerializedMesh& desc, Vector<FBlobJob>& blobJobs, FImportedMesh const& mesh, FUUID skeleton)
@@ -2205,19 +2208,16 @@ void BuildCurveBlobJobs(FSerializedCurve& desc, Vector<FBlobJob>& blobJobs, FImp
 {
     desc = {};
     desc.bounds = BuildCurveBounds(curve);
-    uint32_t segmentCount = CalculateRenderableCurveSegmentCount(curve);
 
     Allocator* scratchAlloc = blobJobs.get_allocator().mResource;
-    Vector<FSerializedCurveSegment> segments(scratchAlloc);
-    Vector<FSerializedCurveAABB> aabbs(scratchAlloc);
-    segments.resize(segmentCount);
-    aabbs.resize(segmentCount);
-    BuildCurveGeometry(curve, Span<FSerializedCurveSegment>(segments.data(), segments.size()),
-                       Span<FSerializedCurveAABB>(aabbs.data(), aabbs.size()));
+    Vector<FCurveDOTSVertex> vertices(scratchAlloc);
+    Vector<uint32_t> indices(scratchAlloc);
+    Vector<FCurveLeaf> leaves(scratchAlloc);
+    BuildDOTSGeometry(curve, vertices, indices, leaves);
 
-    AppendArrayBlobJob(blobJobs, curve.points, FBlobCodec::LZ4, desc.points);
-    AppendArrayBlobJob(blobJobs, segments, FBlobCodec::LZ4, desc.segments);
-    AppendArrayBlobJob(blobJobs, aabbs, FBlobCodec::LZ4, desc.aabbs, alignof(FSerializedCurveAABB));
+    AppendArrayBlobJob(blobJobs, vertices, FBlobCodec::LZ4, desc.vertices);
+    AppendArrayBlobJob(blobJobs, indices, FBlobCodec::LZ4, desc.indices);
+    AppendArrayBlobJob(blobJobs, leaves, FBlobCodec::LZ4, desc.leaves);
 }
 
 FImportedScene::FImportedScene(MemoryMappedFile& file, Allocator* scratchAlloc)
@@ -2282,18 +2282,14 @@ GPUSceneDesc FImportedScene::CalculateGPUSceneDesc(Foundation::RHI::RHIDeviceCap
         primitiveBytes = AlignUp(primitiveBytes, size_t(4));
         primitiveBytes += GPUScene::CalculateMeshPrimitiveSize(mesh);
     }
-    size_t curveAABBBytes = 0;
     for (auto const& curve : GetCurves())
     {
         primitiveBytes = AlignUp(primitiveBytes, size_t(4));
         primitiveBytes += GPUScene::CalculateCurvePrimitiveSize(curve);
-
-        curveAABBBytes = AlignUp(curveAABBBytes, alignof(Foundation::RHI::RHIAccelerationStructureAABB));
-        curveAABBBytes += GPUScene::CalculateCurveAABBSize(curve);
     }
 
     desc.primitiveBudget = ByteGPUSceneBudget(primitiveBytes, desc.primitiveBudget, size_t(4));
-    desc.curveAABBBudget = ByteGPUSceneBudget(curveAABBBytes, desc.curveAABBBudget, alignof(Foundation::RHI::RHIAccelerationStructureAABB));
+    desc.curveAABBBudget = 0;
 
     size_t intersectableLightCount = 0;
     for (auto const& light : GetLights())

--- a/Editor/Scene/Scene.hpp
+++ b/Editor/Scene/Scene.hpp
@@ -170,7 +170,7 @@ struct FSceneGlobals
     uint32_t viewLutHdrIndex{1u};
 };
 static constexpr uint32_t kSceneMagic = fourCC("FSCN");
-static constexpr uint32_t kSceneVersion = 21;
+static constexpr uint32_t kSceneVersion = 22;
 
 // One NLA strip: a source clip (referenced by its animation-group name id) placed on the timeline,
 // optionally retimed and looped within a source-clip window. Matches EXT_foundation_animation.

--- a/Source/Renderer/Curve.hpp
+++ b/Source/Renderer/Curve.hpp
@@ -6,29 +6,28 @@ using namespace Foundation;
 using namespace Core;
 using namespace Math;
 #pragma pack(push, 1)
-struct FCurvePoint
+// Triangle BLAS vertex for DOTS (position + pad for 16-byte stride).
+struct FCurveDOTSVertex
 {
     float3 position;
-    float radius;
+    float pad;
 };
-struct FSerializedCurveSegment
+// Tapered capsule leaf reconstructed at shading time (primitiveIndex / 4).
+struct FCurveLeaf
 {
-    uint32_t p0;
-    uint32_t p1;
+    float3 p0;
+    float r0;
+    float3 p1;
+    float r1;
     float u0;
     float u1;
 };
 #pragma pack(pop)
-struct FSerializedCurveAABB
-{
-    float minX, minY, minZ;
-    float maxX, maxY, maxZ;
-};
 struct FSerializedCurve
 {
     FUUID id{};
     FSerializedBounds bounds;
-    FBlobRef points;
-    FBlobRef segments;
-    FBlobRef aabbs;
+    FBlobRef vertices; // FCurveDOTSVertex
+    FBlobRef indices;  // uint32_t, 12 indices (4 tris) per leaf
+    FBlobRef leaves;   // FCurveLeaf
 };

--- a/Source/Renderer/GPUScene.cpp
+++ b/Source/Renderer/GPUScene.cpp
@@ -256,8 +256,6 @@ struct GPUSceneImpl
     Vector<RHIDeviceScopedHandle<RHIAccelerationStructure>> mCurveBLASes;
     Vector<RHIDeviceScopedHandle<RHIBuffer>> mCurveBLASBuffers;
     Vector<uint32_t> mFreeCurveBLASSlots;
-    RHIDeviceScopedHandle<RHIBuffer> mCurveAABBBuffer;
-    char* mCurveAABBMapped{nullptr};
     // Light BLAS
     RHIDeviceScopedHandle<RHIBuffer> mLightGeometryBuffer;
     RHIDeviceScopedHandle<RHIAccelerationStructure> mRectBLAS;
@@ -273,8 +271,6 @@ struct GPUSceneImpl
     // Validates the TLAS fits the pre-allocated buffers (never grows them); aborts if exceeded.
     void EnsureTLASCapacity(uint32_t totalInstances);
 
-    // VMA-backed byte suballocator over mCurveAABBBuffer.
-    RHIDeviceScopedHandle<RHIVirtualAllocator> mCurveAABBAlloc;
     uint32_t AcquireMeshBLASSlot();
     uint32_t AcquireCurveBLASSlot();
 
@@ -326,7 +322,7 @@ struct GPUSceneImpl
         FBlobDeserializer blobs{Span<const unsigned char>{}};
         const FSerializedMesh* mesh{nullptr};
         const FSerializedCurve* curve{nullptr};
-        size_t footprint{0}; // staging bytes (primitive [+ curve AABB]); 0/1 when direct-mapped.
+        size_t footprint{0}; // staging bytes (primitive); 0/1 when direct-mapped.
     };
     struct PendingTextureUpload
     {
@@ -424,6 +420,15 @@ struct GPUSceneImpl
     }
     void AllocateDynamicBLAS(Geometry& g);
     [[nodiscard]] bool HasDynamicGeometry() const { return !mDynamicGeometrySlots.empty(); }
+    [[nodiscard]] bool HasCurveGeometry() const
+    {
+        for (Geometry const& g : mGeometry)
+        {
+            if (g.live && g.type == kGSInstanceTypeCurve && g.state == ResourceState::Ready)
+                return true;
+        }
+        return false;
+    }
     void BeginDynamicGeometryUpdate();
     Span<std::byte> UpdateDynamicGeometry(GeometryHandle handle);
     void EndDynamicGeometryUpdate();
@@ -439,10 +444,8 @@ size_t GPUScene::CalculateMeshPrimitiveSize(FSerializedMesh const& src)
 
 size_t GPUScene::CalculateCurvePrimitiveSize(FSerializedCurve const& src)
 {
-    return sizeof(GSCurveSet) + src.points.decodedSize + src.segments.decodedSize;
+    return sizeof(GSCurveSet) + src.vertices.decodedSize + src.indices.decodedSize + src.leaves.decodedSize;
 }
-
-size_t GPUScene::CalculateCurveAABBSize(FSerializedCurve const& src) { return src.aabbs.decodedSize; }
 
 // Threaded decode of one blob payload into its mapped staging/direct destination.
 struct GPUSceneBlobDecodeJob final : Foundation::Core::Job
@@ -482,8 +485,6 @@ void GPUSceneImpl::FlushDirectGeometryUpload()
         return;
     if (mPrimitiveAlloc->GetPeakUsage())
         owner.mPrimitiveBuffer->Flush(0, mPrimitiveAlloc->GetPeakUsage());
-    if (mCurveAABBAlloc->GetPeakUsage())
-        mCurveAABBBuffer->Flush(0, mCurveAABBAlloc->GetPeakUsage());
 }
 
 GPUScene::GPUScene(RHIDevice* device, Allocator* allocator, GPUSceneDesc const& desc, AllocatorStack* frameScratch) :
@@ -534,9 +535,8 @@ GPUSceneImpl::GPUSceneImpl(GPUScene& owner, RHIDevice* device, Allocator* alloca
     mTexture2DSlots.reserve(desc.texturesBudget);
     mTexture3DSlots.reserve(kGPUScenePersistentTexture3DBindings + kGPUSceneTextureBindingSlack);
     mPrimitiveAlloc = mDevice->CreateVirtualAllocator(desc.primitiveBudget);
-    mCurveAABBAlloc = mDevice->CreateVirtualAllocator(desc.curveAABBBudget);
     auto caps = mDevice->GetCapabilities();
-    size_t directGeometryBudget = static_cast<size_t>(desc.primitiveBudget) + desc.curveAABBBudget;
+    size_t directGeometryBudget = static_cast<size_t>(desc.primitiveBudget);
     size_t minDirectGeometryHeapSize = std::max(directGeometryBudget, kMinDirectGeometryUploadHeapSize);
     mDirectGeometryUpload = caps.integratedGPU && caps.deviceLocalHostVisibleBuffers &&
         caps.deviceLocalHostVisibleHeapSize >= minDirectGeometryHeapSize;
@@ -548,18 +548,12 @@ GPUSceneImpl::GPUSceneImpl(GPUScene& owner, RHIDevice* device, Allocator* alloca
     owner.mPrimitiveBuffer = mDevice->CreateBuffer(
         {.resource = geoDesc,
          .usage = RHIBufferUsageBits::TransferDestination | RHIBufferUsageBits::StorageBuffer |
-             RHIBufferUsageBits::DeviceAddress | RHIBufferUsageBits::AccelerationStructureBuildReadOnly,
+             RHIBufferUsageBits::DeviceAddress | RHIBufferUsageBits::AccelerationStructureBuildReadOnly |
+             RHIBufferUsageBits::IndexBuffer,
          .size = desc.primitiveBudget});
-    geoDesc.shared = false;
-    mCurveAABBBuffer = mDevice->CreateBuffer(
-        {.resource = geoDesc,
-         .usage = RHIBufferUsageBits::TransferDestination | RHIBufferUsageBits::StorageBuffer |
-             RHIBufferUsageBits::DeviceAddress | RHIBufferUsageBits::AccelerationStructureBuildReadOnly,
-         .size = desc.curveAABBBudget});
     if (mDirectGeometryUpload)
     {
         mPrimitiveMapped = owner.mPrimitiveBuffer->Map<char>();
-        mCurveAABBMapped = mCurveAABBBuffer->Map<char>();
         LOG(GPUScene, LogInfo, "Direct GPU Memory Access available ({} MiB budget used). Uploading via direct copy.",
             directGeometryBudget / (1u << 20));
     }
@@ -802,8 +796,6 @@ GPUSceneImpl::~GPUSceneImpl()
         mUploadThread.join();
     if (mPrimitiveAlloc)
         mPrimitiveAlloc->Clear();
-    if (mCurveAABBAlloc)
-        mCurveAABBAlloc->Clear();
     for (auto& g : mGeometry)
     {
         g.dynBLASBuffer.Reset();
@@ -1077,7 +1069,6 @@ void GPUSceneImpl::DbgGetMemoryStatistics(Vector<MemoryStat>& outStats) const
     };
 
     size_t primitiveBytes = AddBufferSize(owner.mPrimitiveBuffer);
-    size_t curveAABBBytes = AddBufferSize(mCurveAABBBuffer);
     auto texture2DStats = mTexture2DPool.GetStats();
     auto texture3DStats = mTexture3DPool.GetStats();
     size_t instanceBytes = AddRingBufferSize(mInstanceBuffer);
@@ -1099,7 +1090,6 @@ void GPUSceneImpl::DbgGetMemoryStatistics(Vector<MemoryStat>& outStats) const
     size_t defaultBufferBytes = AddBufferSize(owner.mFoundationDefaultBufferFloat);
 
     outStats.push_back({"Primitive Buffer (Buffer)", primitiveBytes});
-    outStats.push_back({"Curve AABB Buffer (Buffer)", curveAABBBytes});
     outStats.push_back({"Texture2D Pool (Texture)", texture2DStats.ownedTextureBytes});
     outStats.push_back({"Texture3D Pool (Texture)", texture3DStats.ownedTextureBytes});
     outStats.push_back({"Instance Buffer (Buffer)", instanceBytes});
@@ -1130,10 +1120,6 @@ String GPUSceneImpl::DbgGetBufferStatistics() const
                    owner.mPrimitiveBuffer->GetAllocationSize() / static_cast<float>(1 << 20u),
                    mPrimitiveAlloc->GetUsedBytes() / static_cast<float>(1 << 20u),
                    owner.mPrimitiveBuffer->mDesc.size / static_cast<float>(1 << 20u));
-    fmt::format_to(std::back_inserter(res), "Curve AABB Buffer: {:.1f} MB allocated, used {:.1f} / {:.1f} MB\n",
-                   mCurveAABBBuffer->GetAllocationSize() / static_cast<float>(1 << 20u),
-                   mCurveAABBAlloc->GetUsedBytes() / static_cast<float>(1 << 20u),
-                   mCurveAABBBuffer->mDesc.size / static_cast<float>(1 << 20u));
     fmt::format_to(std::back_inserter(res),
                    "Texture2D Pool: {:.1f} MB owned, {:.1f} MB referenced, used {} / {} bindings, owned {} textures\n",
                    texture2DStats.ownedTextureBytes / static_cast<float>(1 << 20u),
@@ -1231,26 +1217,25 @@ size_t GPUSceneImpl::StageMesh(ImmediateUpload* ctx, FSerializedMesh const& src,
 
 GPUScene::Result GPUSceneImpl::ReserveCurve(FSerializedCurve const& src, GSCurveSet& outData, uint32_t& outOffset)
 {
-    static_assert(sizeof(FCurvePoint) == sizeof(GSCurvePoint));
-    static_assert(alignof(FCurvePoint) == alignof(GSCurvePoint));
-    static_assert(sizeof(FSerializedCurveSegment) == sizeof(GSCurveSegment));
-    static_assert(alignof(FSerializedCurveSegment) == alignof(GSCurveSegment));
-    static_assert(sizeof(FSerializedCurveAABB) == sizeof(RHIAccelerationStructureAABB));
-    static_assert(alignof(FSerializedCurveAABB) == alignof(RHIAccelerationStructureAABB));
+    static_assert(sizeof(FCurveDOTSVertex) == 16);
+    static_assert(sizeof(FCurveLeaf) == 40);
 
-    if (src.points.decodedSize == 0 || src.segments.count == 0)
+    if (src.vertices.decodedSize == 0 || src.indices.count == 0 || src.leaves.count == 0)
         return Result::InvalidInput;
-    CHECK_MSG(src.points.stride == sizeof(GSCurvePoint), "Serialized curve point stride mismatch");
-    CHECK_MSG(src.segments.stride == sizeof(GSCurveSegment), "Serialized curve segment stride mismatch");
-    CHECK_MSG(src.aabbs.stride == sizeof(RHIAccelerationStructureAABB), "Serialized curve AABB stride mismatch");
-    CHECK_MSG(src.points.decodedSize % sizeof(GSCurvePoint) == 0, "Serialized curve point blob size mismatch");
-    CHECK_MSG(src.segments.decodedSize == sizeof(GSCurveSegment) * src.segments.count,
-              "Serialized curve segment blob size mismatch");
-    CHECK_MSG(src.aabbs.count == src.segments.count, "Serialized curve AABB count mismatch");
-    CHECK_MSG(src.aabbs.decodedSize == sizeof(RHIAccelerationStructureAABB) * src.aabbs.count,
-              "Serialized curve AABB blob size mismatch");
+    CHECK_MSG(src.vertices.stride == sizeof(FCurveDOTSVertex), "Serialized curve vertex stride mismatch");
+    CHECK_MSG(src.indices.stride == sizeof(uint32_t), "Serialized curve index stride mismatch");
+    CHECK_MSG(src.leaves.stride == sizeof(FCurveLeaf), "Serialized curve leaf stride mismatch");
+    CHECK_MSG(src.vertices.decodedSize == sizeof(FCurveDOTSVertex) * src.vertices.count,
+              "Serialized curve vertex blob size mismatch");
+    CHECK_MSG(src.indices.decodedSize == sizeof(uint32_t) * src.indices.count,
+              "Serialized curve index blob size mismatch");
+    CHECK_MSG(src.leaves.decodedSize == sizeof(FCurveLeaf) * src.leaves.count,
+              "Serialized curve leaf blob size mismatch");
+    CHECK_MSG(src.indices.count % 3 == 0, "Serialized curve index count must be a multiple of 3");
+    CHECK_MSG(src.indices.count == src.leaves.count * 12,
+              "Serialized curve DOTS expects 12 indices per leaf; got {} indices for {} leaves", src.indices.count,
+              src.leaves.count);
 
-    const size_t pointCount = static_cast<size_t>(src.points.decodedSize / sizeof(GSCurvePoint));
     const size_t size = GPUScene::CalculateCurvePrimitiveSize(src);
     constexpr size_t kAlign = 4;
     uint64_t base = mPrimitiveAlloc->Allocate(size, kAlign);
@@ -1262,16 +1247,6 @@ GPUScene::Result GPUSceneImpl::ReserveCurve(FSerializedCurve const& src, GSCurve
     }
     outOffset = static_cast<uint32_t>(base);
 
-    const size_t aabbSize = GPUScene::CalculateCurveAABBSize(src);
-    uint64_t aabbBase = mCurveAABBAlloc->Allocate(aabbSize, alignof(RHIAccelerationStructureAABB));
-    if (aabbBase == RHIVirtualAllocator::kInvalidOffset)
-    {
-        mPrimitiveAlloc->Free(outOffset);
-        LOG(GPUScene, LogError, "Curve AABB buffer overflow. Need {} bytes, {} used of {}", aabbSize,
-            mCurveAABBAlloc->GetUsedBytes(), mCurveAABBAlloc->GetCapacity());
-        return Result::OutOfMemory;
-    }
-
     outData = GSCurveSet{};
     uint32_t cursor = 0;
     auto Skip = [&](size_t bytes)
@@ -1281,11 +1256,12 @@ GPUScene::Result GPUSceneImpl::ReserveCurve(FSerializedCurve const& src, GSCurve
         return off;
     };
     Skip(sizeof(GSCurveSet));
-    outData.pointCount = static_cast<uint32_t>(pointCount);
-    outData.pointOffset = outOffset + Skip(static_cast<size_t>(src.points.decodedSize));
-    outData.segmentCount = static_cast<uint32_t>(src.segments.count);
-    outData.segmentOffset = outOffset + Skip(static_cast<size_t>(src.segments.decodedSize));
-    outData.aabbOffset = static_cast<uint32_t>(aabbBase);
+    outData.vtxCount = static_cast<uint32_t>(src.vertices.count);
+    outData.vtxOffset = outOffset + Skip(static_cast<size_t>(src.vertices.decodedSize));
+    outData.idxCount = static_cast<uint32_t>(src.indices.count);
+    outData.idxOffset = outOffset + Skip(static_cast<size_t>(src.indices.decodedSize));
+    outData.leafCount = static_cast<uint32_t>(src.leaves.count);
+    outData.leafOffset = outOffset + Skip(static_cast<size_t>(src.leaves.decodedSize));
     CHECK_MSG(cursor == size, "Curve layout mismatch: expected {} got {}", size, cursor);
     return Result::InProgress;
 }
@@ -1294,32 +1270,26 @@ size_t GPUSceneImpl::StageCurve(ImmediateUpload* ctx, FSerializedCurve const& sr
                                 uint32_t offset, Vector<BlobCopyTask>& outWrites)
 {
     const size_t size = GPUScene::CalculateCurvePrimitiveSize(src);
-    const size_t aabbSize = GPUScene::CalculateCurveAABBSize(src);
     char* ptr = nullptr;
-    char* aabbPtr = nullptr;
     if (mDirectGeometryUpload)
     {
         CHECK(mPrimitiveMapped != nullptr);
-        CHECK(mCurveAABBMapped != nullptr);
         ptr = mPrimitiveMapped + offset;
-        aabbPtr = mCurveAABBMapped + header.aabbOffset;
     }
     else
     {
-        if (ctx->ptr + size + aabbSize > ctx->end)
+        if (ctx->ptr + size > ctx->end)
             return 0;
         ptr = ctx->Upload(owner.mPrimitiveBuffer.Get(), size, offset);
         CHECK(ptr != nullptr);
-        aabbPtr = ctx->Upload(mCurveAABBBuffer.Get(), aabbSize, header.aabbOffset);
-        CHECK(aabbPtr != nullptr);
     }
     std::memcpy(ptr, &header, sizeof(GSCurveSet));
     auto AppendBlobWrite = [&](FBlobRef const& blob, char* dstPtr)
     { outWrites.push_back({blob, dstPtr, static_cast<size_t>(blob.decodedSize)}); };
-    AppendBlobWrite(src.points, ptr + (header.pointOffset - offset));
-    AppendBlobWrite(src.segments, ptr + (header.segmentOffset - offset));
-    AppendBlobWrite(src.aabbs, aabbPtr);
-    return size + aabbSize;
+    AppendBlobWrite(src.vertices, ptr + (header.vtxOffset - offset));
+    AppendBlobWrite(src.indices, ptr + (header.idxOffset - offset));
+    AppendBlobWrite(src.leaves, ptr + (header.leafOffset - offset));
+    return size;
 }
 
 static bool IsTexture3DView(RHITextureDimension dimension) { return dimension == RHITextureDimension::E3D; }
@@ -1469,8 +1439,7 @@ GPUScene::Result GPUSceneImpl::Upload(FBlobDeserializer* blobs, FSerializedCurve
         g.state = ResourceState::Queued;
         g.live = true;
         outHandle = {slot, generation};
-        const size_t footprint =
-            GPUScene::CalculateCurvePrimitiveSize(source) + GPUScene::CalculateCurveAABBSize(source);
+        const size_t footprint = GPUScene::CalculateCurvePrimitiveSize(source);
         pending = {.handle = outHandle,
                    .blobs = *blobs,
                    .mesh = nullptr,
@@ -1731,9 +1700,9 @@ void GPUSceneImpl::ProcessUploads(Vector<PendingGeometryUpload>& geometry, Vecto
         }
         else if (p.curve)
         {
-            IncludeBlobScratch(p.curve->points);
-            IncludeBlobScratch(p.curve->segments);
-            IncludeBlobScratch(p.curve->aabbs);
+            IncludeBlobScratch(p.curve->vertices);
+            IncludeBlobScratch(p.curve->indices);
+            IncludeBlobScratch(p.curve->leaves);
         }
     }
     size_t textureSubresCount = 0;
@@ -2144,18 +2113,25 @@ void GPUSceneImpl::BuildCurveBLAS(ImmediateContext* ctx, Span<const GSCurveSet> 
     Vector<uint32_t> scratchOffsets(curves.size(), mAllocator);
     StackArena<4096> sizeInfoArena;
     AllocatorStack sizeInfoScratch(sizeInfoArena);
+    auto* primitiveBuffer = owner.mPrimitiveBuffer.Get();
     uint32_t scratchOffset = 0, blasOffset = 0;
     for (size_t i = 0; i < curves.size(); i++)
     {
         auto const& curve = curves[i];
         auto& geo = geometries[i];
         auto& range = buildRanges[i];
-        geo.type = RHIAccelerationGeometryType::AABBs;
-        geo.aabbData = RHIAccelerationStructureGeometryAABBData{.aabbBuffer = mCurveAABBBuffer.Get(),
-                                                                .offset = curve.aabbOffset,
-                                                                .count = curve.segmentCount,
-                                                                .stride = sizeof(RHIAccelerationStructureAABB)};
-        range = RHIAccelerationStructureBuildRangeInfo{.primitiveCount = curve.segmentCount};
+        geo.type = RHIAccelerationGeometryType::Triangles;
+        geo.triangleData = RHIAccelerationStructureGeometryTriangleData{
+            .vertexFormat = RHIResourceFormat::R32G32B32A32SignedFloat,
+            .vertexBuffer = primitiveBuffer,
+            .vertexOffset = curve.vtxOffset,
+            .vertexCount = curve.vtxCount,
+            .vertexStride = sizeof(FCurveDOTSVertex),
+            .indexFormat = RHIResourceFormat::R32Uint,
+            .indexBuffer = primitiveBuffer,
+            .indexOffset = curve.idxOffset,
+            .indexCount = curve.idxCount};
+        range = RHIAccelerationStructureBuildRangeInfo{.primitiveCount = curve.idxCount / 3};
         auto& desc = buildDesc[i];
         desc =
             RHIAccelerationStructureBuildDesc{.type = RHIAccelerationStructureType::BottomLevel,
@@ -2183,7 +2159,6 @@ void GPUSceneImpl::BuildCurveBLAS(ImmediateContext* ctx, Span<const GSCurveSet> 
                               .alignment = 256});
 
     RHIBuffer* blasBuffer = mCurveBLASBuffers.back().Get();
-    Vector<RHIDeviceScopedHandle<RHIAccelerationStructure>> newBLASes(curves.size(), mAllocator);
     auto* cmd = ctx->Get();
     cmd->Begin();
     for (size_t i = 0; i < curves.size(); i++)
@@ -2548,7 +2523,6 @@ void GPUSceneImpl::FreeGeometry(uint32_t slot)
         mPrimitiveAlloc->Free(g.resourceOffset);
         if (g.type == kGSInstanceTypeCurve)
         {
-            mCurveAABBAlloc->Free(g.curve.aabbOffset);
             if (g.blasSlot < mCurveBLASes.size())
             {
                 mCurveBLASes[g.blasSlot].Reset();
@@ -2730,6 +2704,7 @@ GPUScene::TLASBuildResult GPUSceneImpl::BuildTLAS(RHICommandList* cmd, bool upda
         {
             res.mask = 0x04; // CURVE_MASK
             res.shaderBindingTableRecordOffset = kCurveSBTOffset;
+            res.flags = RHIAccelerationGeometryInstanceFlagsBits::TriangleCullDisable;
         }
         else
         {
@@ -2987,7 +2962,6 @@ void GPUSceneImpl::Reset()
     mMeshletGlobalCounter = 0;
     owner.mLastTLASInstancesCount = 0;
     mPrimitiveAlloc->Clear();
-    mCurveAABBAlloc->Clear();
     if (mDynamicPrimitiveAlloc)
         mDynamicPrimitiveAlloc->Clear();
     mDynamicGeometrySlots.clear();
@@ -3053,6 +3027,7 @@ void GPUScene::Collect() { mImpl->Collect(); }
 void GPUScene::Reset() { mImpl->Reset(); }
 
 bool GPUScene::HasDynamicGeometry() const { return mImpl->HasDynamicGeometry(); }
+bool GPUScene::HasCurveGeometry() const { return mImpl->HasCurveGeometry(); }
 void GPUScene::BeginDynamicGeometryUpdate() { mImpl->BeginDynamicGeometryUpdate(); }
 Span<std::byte> GPUScene::UpdateDynamicGeometry(GeometryHandle handle) { return mImpl->UpdateDynamicGeometry(handle); }
 void GPUScene::EndDynamicGeometryUpdate() { mImpl->EndDynamicGeometryUpdate(); }

--- a/Source/Renderer/GPUScene.hpp
+++ b/Source/Renderer/GPUScene.hpp
@@ -177,37 +177,26 @@ struct GSLight
 };
 struct GSCurveSet
 {
-    uint32_t pointOffset; // GSCurvePoint, in Primitive buffer (bytes)
-    uint32_t pointCount;
-    uint32_t segmentOffset; // GSCurveSegment, in Primitive buffer (bytes)
-    uint32_t segmentCount;
-    uint32_t aabbOffset; // RHIAccelerationStructureAABB, in curve AABB buffer (bytes)
-};
-struct GSCurvePoint
-{
-    float3 position;
-    float radius;
-};
-struct GSCurveSegment
-{
-    uint32_t p0;
-    uint32_t p1;
-    float u0;
-    float u1;
+    uint32_t vtxOffset; // FCurveDOTSVertex, in Primitive buffer (bytes)
+    uint32_t vtxCount;
+    uint32_t idxOffset; // uint32_t, in Primitive buffer (bytes)
+    uint32_t idxCount;  // 12 indices (4 tris) per leaf
+    uint32_t leafOffset; // FCurveLeaf, in Primitive buffer (bytes)
+    uint32_t leafCount;
 };
 #pragma pack(pop)
 static_assert(sizeof(GSMesh) == 44);
 static_assert(sizeof(GSInstance) == 104);
 static_assert(sizeof(GSMaterial) == 192);
 static_assert(sizeof(GSLight) == 88);
-static_assert(sizeof(GSCurveSet) == 20);
-static_assert(sizeof(GSCurvePoint) == 16);
-static_assert(sizeof(GSCurveSegment) == 16);
+static_assert(sizeof(GSCurveSet) == 24);
+static_assert(sizeof(FCurveDOTSVertex) == 16);
+static_assert(sizeof(FCurveLeaf) == 40);
 
 struct GPUSceneDesc
 {
     uint32_t primitiveBudget = 16 * (1u << 20); // 16MB
-    uint32_t curveAABBBudget = 16 * (1u << 20); // 16MB
+    uint32_t curveAABBBudget = 0; // unused; retained for ABI of CalculateGPUSceneDesc callers
     uint32_t instanceBudget = static_cast<uint32_t>(1e4); // # of GSInstance elements (ring)
     uint32_t materialBudget = static_cast<uint32_t>(1e3); // # of materials (ring)
     uint32_t lightBudget = static_cast<uint32_t>(1e4); // # of lights (ring)
@@ -269,7 +258,6 @@ public:
 
     [[nodiscard]] static size_t CalculateMeshPrimitiveSize(FSerializedMesh const& src);
     [[nodiscard]] static size_t CalculateCurvePrimitiveSize(FSerializedCurve const& src);
-    [[nodiscard]] static size_t CalculateCurveAABBSize(FSerializedCurve const& src);
 
     GPUScene(RHIDevice* device, Allocator* allocator, GPUSceneDesc const& desc, AllocatorStack* frameScratch = nullptr);
     ~GPUScene();
@@ -441,6 +429,8 @@ public:
      * guards the per-frame getters. */
     /** @brief True when at least one dynamic geometry is resident. */
     [[nodiscard]] bool HasDynamicGeometry() const;
+    /** @brief True when at least one ready curve (DOTS) geometry is resident. */
+    [[nodiscard]] bool HasCurveGeometry() const;
     /**
      * @brief Opens the per-frame dynamic-geometry update window and advances the ring to the next
      *        frame slot. Call exactly once per rendered frame before any @ref UpdateDynamicGeometry.

--- a/Source/Renderer/Rasterizer.cpp
+++ b/Source/Renderer/Rasterizer.cpp
@@ -39,6 +39,7 @@ constexpr size_t kMeshWorkGroupSize = 64;
 constexpr size_t kMaxMeshletCount = 1e6;
 constexpr size_t kMaxMeshletTaskWorkCount = kMaxMeshletCount / kMeshWorkGroupSize;
 constexpr size_t kMaxDynamicDraws = 4096; // dynamic geometry instances drawn per frame (raster)
+constexpr size_t kMaxCurveDraws = 4096; // curve (DOTS) instances drawn per frame (raster)
 constexpr size_t kDisableRTBuildFlags = kViewOverdraw | kViewMeshlet | kViewBaseColor | kViewNormal | kViewPosition | kViewMatcap;
 constexpr RHIResourceFormat kGBufferNormalFormat = RHIResourceFormat::A2B10G10R10Unorm;
 
@@ -585,6 +586,119 @@ void BuildRasterRenderGraph(Renderer* renderer, RendererUBO* globals, GPUScene* 
                 cmd->EndGraphics();
             });
     }
+    /* Curves (DOTS triangles): static Primitive-buffer MDI path, cull-disabled like the TLAS. */
+    ResourceHandle CurveMotionDrawCmds = kInvalidHandle;
+    ResourceHandle CurveMotionDrawCount = kInvalidHandle;
+    ResourceHandle CurveMotionDrawInstanceIDs = kInvalidHandle;
+    if (gpu->HasCurveGeometry())
+    {
+        auto CurveDrawCmds = renderer->CreateResource(
+            "Curve Draw Commands",
+            RHIBufferDesc{.usage = IndirectBuffer | StorageBuffer | TransferDestination,
+                          .size = sizeof(DrawIndexedIndirectCommand) * kMaxCurveDraws});
+        auto CurveDrawCount = renderer->CreateResource(
+            "Curve Draw Count",
+            RHIBufferDesc{.usage = IndirectBuffer | StorageBuffer | TransferDestination, .size = sizeof(uint32_t)});
+        auto CurveDrawInstanceIDs = renderer->CreateResource(
+            "Curve Draw Instance IDs",
+            RHIBufferDesc{.usage = StorageBuffer | TransferDestination, .size = sizeof(uint32_t) * kMaxCurveDraws});
+        CurveMotionDrawCmds = renderer->CreateResource(
+            "Curve Motion Draw Commands",
+            RHIBufferDesc{.usage = IndirectBuffer | StorageBuffer | TransferDestination,
+                          .size = sizeof(DrawIndexedIndirectCommand) * kMaxCurveDraws});
+        CurveMotionDrawCount = renderer->CreateResource(
+            "Curve Motion Draw Count",
+            RHIBufferDesc{.usage = IndirectBuffer | StorageBuffer | TransferDestination, .size = sizeof(uint32_t)});
+        CurveMotionDrawInstanceIDs = renderer->CreateResource(
+            "Curve Motion Draw Instance IDs",
+            RHIBufferDesc{.usage = StorageBuffer | TransferDestination, .size = sizeof(uint32_t) * kMaxCurveDraws});
+        renderer->CreatePass(
+            "Curve Draw Gen", RHIDeviceQueueType::Graphics, 0u,
+            [=](PassHandle self, Renderer* r)
+            {
+                r->BindBufferCopyDst(self, CurveDrawCount);
+                r->BindBufferCopyDst(self, CurveMotionDrawCount);
+                r->BindShader(self, RHIShaderStageBits::Compute, "main",
+                              PathsResolve("Data/Shaders/ECSCurveIndirectDraw.spv"));
+                r->BindBufferUniform(self, GlobalUBO, RHIPipelineStageBits::ComputeShader, "globalParams");
+                r->BindBufferStorageRead(self, InstanceBuffer, RHIPipelineStageBits::ComputeShader, "instances");
+                r->BindBufferStorageRead(self, PrimitiveBuffer, RHIPipelineStageBits::ComputeShader, "primitive");
+                r->BindBufferUnordered(self, CurveDrawCmds, RHIPipelineStageBits::ComputeShader, "outDrawCmds");
+                r->BindBufferUnordered(self, CurveDrawInstanceIDs, RHIPipelineStageBits::ComputeShader,
+                                       "outDrawInstanceIDs");
+                r->BindBufferUnordered(self, CurveDrawCount, RHIPipelineStageBits::ComputeShader, "outDrawCount");
+                r->BindBufferUnordered(self, CurveMotionDrawCmds, RHIPipelineStageBits::ComputeShader,
+                                       "outMotionDrawCmds");
+                r->BindBufferUnordered(self, CurveMotionDrawInstanceIDs, RHIPipelineStageBits::ComputeShader,
+                                       "outMotionDrawInstanceIDs");
+                r->BindBufferUnordered(self, CurveMotionDrawCount, RHIPipelineStageBits::ComputeShader,
+                                       "outMotionDrawCount");
+            },
+            [=](PassHandle self, Renderer* r, RHICommandList* cmd)
+            {
+                cmd->FillBuffer(r->DerefResource(CurveDrawCount).Get<RHIBuffer*>(), 0u);
+                cmd->FillBuffer(r->DerefResource(CurveMotionDrawCount).Get<RHIBuffer*>(), 0u);
+                r->CmdSetPipeline(self, cmd);
+                r->CmdDispatch(self, cmd, {globals->numInstances, 1, 1});
+            });
+        using RasterizerState = RHIPipelineState::PipelineStateDesc::Rasterizer;
+        RasterizerState const curveRaster{.cullMode = RasterizerState::CullNone};
+        renderer->CreatePass(
+            "Curve GBuffer", RHIDeviceQueueType::Graphics, 0u,
+            [=](PassHandle self, Renderer* r)
+            {
+                r->BindShader(self, RHIShaderStageBits::Vertex, "main", PathsResolve("Data/Shaders/EVSCurveDraw.spv"));
+                r->BindShader(self, RHIShaderStageBits::Fragment, "main", PathsResolve("Data/Shaders/EPSGBuffer.spv"),
+                              AsBytes(AsSpan(gbufferFlags)));
+                r->BindBufferUniform(self, GlobalUBO, RHIPipelineStageBits::AllGraphics, "globalParams");
+                r->BindBufferStorageRead(self, InstanceBuffer, RHIPipelineStageBits::AllGraphics, "instances");
+                r->BindBufferStorageRead(self, PrimitiveBuffer, RHIPipelineStageBits::AllGraphics, "primitive");
+                r->BindBufferStorageRead(self, CurveDrawInstanceIDs, RHIPipelineStageBits::AllGraphics,
+                                         "drawInstanceIDs");
+                r->BindBufferStorageRead(self, MaterialBuffer, RHIPipelineStageBits::AllGraphics, "materials");
+                r->BindTextureRTV(self, GBufferRT0,
+                                  {.format = RHIResourceFormat::R8G8B8A8Unorm,
+                                   .range = RHITextureSubresourceRange::Create(RHITextureAspectFlagBits::Color)});
+                r->BindTextureRTV(self, GBufferRT1,
+                                  {.format = kGBufferNormalFormat,
+                                   .range = RHITextureSubresourceRange::Create(RHITextureAspectFlagBits::Color)});
+                r->BindTextureRTV(self, GBufferRT2,
+                                  {.format = RHIResourceFormat::B10G11R11Ufloat,
+                                   .range = RHITextureSubresourceRange::Create(RHITextureAspectFlagBits::Color)});
+                r->BindTextureRTV(self, InstanceIDBuffer,
+                                  {.format = RHIResourceFormat::R32Uint,
+                                   .range = RHITextureSubresourceRange::Create(RHITextureAspectFlagBits::Color)});
+                r->BindTextureUAV(self, OverdrawBuffer, "overdraw", RHIPipelineStageBits::FragmentShader,
+                                  {.format = RHIResourceFormat::R32Uint,
+                                   .range = RHITextureSubresourceRange::Create(RHITextureAspectFlagBits::Color)});
+                r->BindTextureDSV(self, Depth,
+                                  {.format = RHIResourceFormat::D32SignedFloat,
+                                   .range = RHITextureSubresourceRange::Create(RHITextureAspectFlagBits::Depth)});
+                r->BindBufferIndirectRead(self, CurveDrawCmds);
+                r->BindBufferIndirectRead(self, CurveDrawCount);
+                r->BindTextureSampler(self, TexSampler, "textureSampler");
+                r->BindDescriptorSet(self, "textures", gpu->GetTexture2DPool()->GetDescriptorSetLayout());
+                r->PassSetRasterizerFlags(self, curveRaster);
+            },
+            [=](PassHandle self, Renderer* r, RHICommandList* cmd)
+            {
+                RHIExtent2D wh{w, h};
+                r->CmdBeginGraphics(self, cmd, wh,
+                                    {{{RHIAttachmentLoadOp::Load},
+                                      {RHIAttachmentLoadOp::Load},
+                                      {RHIAttachmentLoadOp::Load},
+                                      {RHIAttachmentLoadOp::Load}}},
+                                    {RHIAttachmentLoadOp::Load});
+                r->CmdSetPipeline(self, cmd);
+                cmd->SetViewport(0, 0, w, h, 0, 1, true).SetScissor(0, 0, w, h);
+                r->CmdBindDescriptorSet(self, cmd, "textures", gpu->GetTexture2DPool()->GetDescriptorSet());
+                cmd->BindIndexBuffer(gpu->GetPrimitiveBuffer(), 0, RHIResourceFormat::R32Uint);
+                auto* cmds = r->DerefResource(CurveDrawCmds).Get<RHIBuffer*>();
+                auto* count = r->DerefResource(CurveDrawCount).Get<RHIBuffer*>();
+                cmd->DrawIndexedIndirectCount(cmds, 0, count, 0, kMaxCurveDraws, sizeof(DrawIndexedIndirectCommand));
+                cmd->EndGraphics();
+            });
+    }
     renderer->CreatePass(
         "Camera Motion Vectors", RHIDeviceQueueType::Graphics, 0u,
         [=](PassHandle self, Renderer* r)
@@ -682,6 +796,49 @@ void BuildRasterRenderGraph(Renderer* renderer, RendererUBO* globals, GPUScene* 
                     auto* cmds = r->DerefResource(motionCmds).Get<RHIBuffer*>();
                     auto* count = r->DerefResource(motionCount).Get<RHIBuffer*>();
                     cmd->DrawIndexedIndirectCount(cmds, 0, count, 0, kMaxDynamicDraws,
+                                                  sizeof(DrawIndexedIndirectCommand));
+                    cmd->EndGraphics();
+                });
+        }
+        if (gpu->HasCurveGeometry())
+        {
+            auto motionCmds = CurveMotionDrawCmds;
+            auto motionCount = CurveMotionDrawCount;
+            auto motionIDs = CurveMotionDrawInstanceIDs;
+            using RasterizerState = RHIPipelineState::PipelineStateDesc::Rasterizer;
+            RasterizerState const curveRaster{.cullMode = RasterizerState::CullNone};
+            renderer->CreatePass(
+                "Motion Vectors [Curves]", RHIDeviceQueueType::Graphics, 0u,
+                [=](PassHandle self, Renderer* r)
+                {
+                    r->BindShader(self, RHIShaderStageBits::Vertex, "main",
+                                  PathsResolve("Data/Shaders/EVSCurveMotionDraw.spv"));
+                    r->BindShader(self, RHIShaderStageBits::Fragment, "main",
+                                  PathsResolve("Data/Shaders/EPSMotionVector.spv"));
+                    r->BindBufferUniform(self, GlobalUBO, RHIPipelineStageBits::AllGraphics, "globalParams");
+                    r->BindBufferStorageRead(self, InstanceBuffer, RHIPipelineStageBits::AllGraphics, "instances");
+                    r->BindBufferStorageRead(self, PrimitiveBuffer, RHIPipelineStageBits::AllGraphics, "primitive");
+                    r->BindBufferStorageRead(self, motionIDs, RHIPipelineStageBits::AllGraphics, "drawInstanceIDs");
+                    r->BindTextureRTV(self, MotionVectorRT,
+                                      {.format = RHIResourceFormat::R16G16SignedFloat,
+                                       .range = RHITextureSubresourceRange::Create(RHITextureAspectFlagBits::Color)});
+                    r->BindTextureDSV(self, Depth,
+                                      {.format = RHIResourceFormat::D32SignedFloat,
+                                       .range = RHITextureSubresourceRange::Create(RHITextureAspectFlagBits::Depth)});
+                    r->BindBufferIndirectRead(self, motionCmds);
+                    r->BindBufferIndirectRead(self, motionCount);
+                    r->PassSetRasterizerFlags(self, curveRaster, motionDepth);
+                },
+                [=](PassHandle self, Renderer* r, RHICommandList* cmd)
+                {
+                    RHIExtent2D wh{w, h};
+                    r->CmdBeginGraphics(self, cmd, wh, {{{RHIAttachmentLoadOp::Load}}}, {RHIAttachmentLoadOp::Load});
+                    r->CmdSetPipeline(self, cmd);
+                    cmd->SetViewport(0, 0, w, h, 0, 1, true).SetScissor(0, 0, w, h);
+                    cmd->BindIndexBuffer(gpu->GetPrimitiveBuffer(), 0, RHIResourceFormat::R32Uint);
+                    auto* cmds = r->DerefResource(motionCmds).Get<RHIBuffer*>();
+                    auto* count = r->DerefResource(motionCount).Get<RHIBuffer*>();
+                    cmd->DrawIndexedIndirectCount(cmds, 0, count, 0, kMaxCurveDraws,
                                                   sizeof(DrawIndexedIndirectCommand));
                     cmd->EndGraphics();
                 });

--- a/Source/Renderer/Shaders/ECSCurveIndirectDraw.slang
+++ b/Source/Renderer/Shaders/ECSCurveIndirectDraw.slang
@@ -1,0 +1,44 @@
+// Builds the GPU-driven indirect draw list for DOTS curve instances: one
+// VkDrawIndexedIndirectCommand per curve, consumed by EVSCurveDraw + EPSGBuffer.
+// Curves skip the meshlet pipeline (ECSCullInstances) and the dynamic MDI path.
+#include "ICommon.slang"
+
+public static const uint32_t kGSInstanceTypeCurve = 1u;
+
+uniform UBO globalParams;
+StructuredBuffer<GSInstance> instances;
+ByteAddressBuffer primitive;
+RWStructuredBuffer<DrawIndexedIndirectCommand> outDrawCmds;
+RWStructuredBuffer<uint> outDrawInstanceIDs;
+RWStructuredBuffer<Atomic<uint>> outDrawCount;
+RWStructuredBuffer<DrawIndexedIndirectCommand> outMotionDrawCmds;
+RWStructuredBuffer<uint> outMotionDrawInstanceIDs;
+RWStructuredBuffer<Atomic<uint>> outMotionDrawCount;
+
+[shader("compute")]
+[numthreads(64, 1, 1)]
+void main(uint tid: SV_DispatchThreadID)
+{
+    if (tid >= globalParams.numInstances)
+        return;
+    uint iid = tid + globalParams.firstInstance;
+    GSInstance inst = instances[iid];
+    if (GSInstanceType(inst) != kGSInstanceTypeCurve)
+        return;
+    GSCurveSet curve = primitive.Load<GSCurveSet>(inst.resourceOffset);
+    uint draw = outDrawCount[0].add(1);
+    DrawIndexedIndirectCommand cmd;
+    cmd.indexCount = curve.idxCount;
+    cmd.instanceCount = 1;
+    cmd.firstIndex = curve.idxOffset / 4u;
+    cmd.vertexOffset = 0;
+    cmd.firstInstance = 0;
+    outDrawCmds[draw] = cmd;
+    outDrawInstanceIDs[draw] = iid;
+    if (GSInstanceHasMotion(inst, globalParams.frameNumber))
+    {
+        uint motionDraw = outMotionDrawCount[0].add(1);
+        outMotionDrawCmds[motionDraw] = cmd;
+        outMotionDrawInstanceIDs[motionDraw] = iid;
+    }
+}

--- a/Source/Renderer/Shaders/ECSLighting.slang
+++ b/Source/Renderer/Shaders/ECSLighting.slang
@@ -16,6 +16,9 @@ RWTexture2D<float4> diffuseOutput;
 RWTexture2D<float4> specularOutput;
 RaytracingAccelerationStructure AS;
 
+static const uint kMeshMask = 0x01;
+static const uint kCurveMask = 0x04;
+
 bool shadow(float3 p, float3 l, float tMax = INF)
 {
     RayDesc ray;
@@ -24,7 +27,7 @@ bool shadow(float3 p, float3 l, float tMax = INF)
     ray.TMin = EPS_TMin;
     ray.TMax = tMax;
     RayQuery<RAY_FLAG_ACCEPT_FIRST_HIT_AND_END_SEARCH> q;
-    q.TraceRayInline(AS, RAY_FLAG_ACCEPT_FIRST_HIT_AND_END_SEARCH, 0xFF, ray);
+    q.TraceRayInline(AS, RAY_FLAG_ACCEPT_FIRST_HIT_AND_END_SEARCH, kMeshMask | kCurveMask, ray);
     while (q.Proceed()){
         // Not alpha tested. A hit is a shadow.
         q.CommitNonOpaqueTriangleHit();

--- a/Source/Renderer/Shaders/ERTPathTracer.slang
+++ b/Source/Renderer/Shaders/ERTPathTracer.slang
@@ -305,103 +305,120 @@ float2 GetHitUV(uint meshOffset, uint primitive, float2 bary, GSInstance inst)
     return GetHitUV(primitives, meshOffset, primitive, bary);
 }
 
-float4 LoadCurveControl(GSCurveSet curve, uint32_t pointIndex)
+// Infinite tapered-cone intersector (Inigo Quilez, MIT) with origin re-centering
+// for numerical stability (Ray Tracing Gems II, ch. 34).
+float4 IntersectInfiniteCone(float3 ro, float3 rd, float3 pa, float3 pb, float ra, float rb)
 {
-    GSCurvePoint p = primitives.Load<GSCurvePoint>(curve.pointOffset + pointIndex * sizeof(GSCurvePoint));
-    return float4(p.position, p.radius);
+    float3 oa = ro - pa;
+    float tOffset = -dot(rd, oa);
+    float3 roOffset = tOffset * rd;
+    oa = ro + roOffset - pa;
+
+    float3 ba = pb - pa;
+    float rr = ra - rb;
+    float m0 = dot(ba, ba);
+    float m1 = dot(ba, oa);
+    float m2 = dot(ba, rd);
+    float m3 = dot(rd, oa);
+    float m5 = dot(oa, oa);
+    float d2 = m0 - rr * rr;
+
+    float k2 = d2 - m2 * m2;
+    float k1 = d2 * m3 - m1 * m2 + m2 * rr * ra;
+    float k0 = d2 * m5 - m1 * m1 + m1 * rr * ra * 2.0f - m0 * ra * ra;
+
+    float h = k1 * k1 - k0 * k2;
+    if (h < 0.0f)
+        return float4(-1.0f, 0.0f, 0.0f, 0.0f);
+
+    float t = (-sqrt(h) - k1) / k2;
+    if (t + tOffset < 0.0f)
+        return float4(-1.0f, 0.0f, 0.0f, 0.0f);
+
+    float y = m1 - ra * rr + t * m2;
+    float3 hitPoint = d2 * (oa + t * rd);
+    float3 axisPoint = ba * y;
+    float3 normal = normalize(hitPoint - axisPoint);
+    return float4(t + tOffset, normal);
 }
 
-bool IsBezierCurveSegment(GSCurveSet curve, GSCurveSegment segment)
+GSCurveLeaf LoadCurveLeaf(GSCurveSet curve, uint primitive)
 {
-    return segment.p1 == segment.p0 + 3 && segment.p1 < curve.pointCount;
+    uint leafIndex = primitive / 4u;
+    return primitives.Load<GSCurveLeaf>(curve.leafOffset + leafIndex * sizeof(GSCurveLeaf));
 }
 
-float4 EvaluateCubicBezier(float4 q0, float4 q1, float4 q2, float4 q3, float u)
-{
-    float4 q01 = lerp(q0, q1, u);
-    float4 q12 = lerp(q1, q2, u);
-    float4 q23 = lerp(q2, q3, u);
-    float4 q012 = lerp(q01, q12, u);
-    float4 q123 = lerp(q12, q23, u);
-    return lerp(q012, q123, u);
-}
-
-float4 EvaluateCubicBezierDerivative(float4 q0, float4 q1, float4 q2, float4 q3, float u)
-{
-    float4 d0 = q1 - q0;
-    float4 d1 = q2 - q1;
-    float4 d2 = q3 - q2;
-    return 3.0f * lerp(lerp(d0, d1, u), lerp(d1, d2, u), u);
-}
-
-HitState GetCurveHitState(uint curveOffset, uint primitive, float2 uv, GSInstance inst,
+HitState GetCurveHitState(uint curveOffset, uint primitive, float2 /*triangleBary*/, GSInstance inst,
                           float3 rayOrigin, float3 rayDirection, float hitT)
 {
     HitState hit;
     hit.uvDX = float2(0.0f);
     hit.uvDY = float2(0.0f);
-    hit.position = rayOrigin + rayDirection * hitT;
-    hit.uv = uv;
 
     GSCurveSet curve = primitives.Load<GSCurveSet>(curveOffset);
-    GSCurveSegment segment = primitives.Load<GSCurveSegment>(curve.segmentOffset + primitive * sizeof(GSCurveSegment));
-    GSCurvePoint p0 = primitives.Load<GSCurvePoint>(curve.pointOffset + segment.p0 * sizeof(GSCurvePoint));
-    GSCurvePoint p1 = primitives.Load<GSCurvePoint>(curve.pointOffset + segment.p1 * sizeof(GSCurvePoint));
+    GSCurveLeaf leaf = LoadCurveLeaf(curve, primitive);
 
-    float3 tangentVector;
-    if (IsBezierCurveSegment(curve, segment))
+    float3 objRo = inst.rotation.conjugate().rotate(rayOrigin - inst.transform) / inst.scale;
+    float3 objRd = inst.rotation.conjugate().rotate(rayDirection) / inst.scale;
+    if (LengthSquared(objRd) <= 1e-12f)
+        objRd = float3(0.0f, 0.0f, 1.0f);
+
+    float3 axis = leaf.p1 - leaf.p0;
+    float axisLen2 = LengthSquared(axis);
+    float3 tangent = axisLen2 > 1e-12f ? normalize(axis) : float3(0.0f, 1.0f, 0.0f);
+
+    float4 coneHit = IntersectInfiniteCone(objRo, objRd, leaf.p0, leaf.p1, leaf.r0, leaf.r1);
+    float3 localNormal;
+    float localU;
+    if (coneHit.x >= 0.0f)
     {
-        float localU = saturate((uv.x - segment.u0) / max(segment.u1 - segment.u0, 1e-7f));
-        float4 q0 = float4(p0.position, p0.radius);
-        float4 q1 = LoadCurveControl(curve, segment.p0 + 1);
-        float4 q2 = LoadCurveControl(curve, segment.p0 + 2);
-        float4 q3 = float4(p1.position, p1.radius);
-        float4 dq = EvaluateCubicBezierDerivative(q0, q1, q2, q3, localU);
-        tangentVector = dq.xyz;
+        localNormal = coneHit.yzw;
+        float3 objHit = objRo + objRd * coneHit.x;
+        localU = axisLen2 > 1e-12f ? saturate(dot(objHit - leaf.p0, axis) / axisLen2) : 0.0f;
     }
     else
     {
-        float3 axis = p1.position - p0.position;
-        tangentVector = axis;
+        // Degenerate / near-parallel fallback: project the triangle hit onto the segment.
+        float3 worldHit = rayOrigin + rayDirection * hitT;
+        float3 objHit = inst.rotation.conjugate().rotate(worldHit - inst.transform) / inst.scale;
+        localU = axisLen2 > 1e-12f ? saturate(dot(objHit - leaf.p0, axis) / axisLen2) : 0.0f;
+        float3 axisPoint = lerp(leaf.p0, leaf.p1, localU);
+        float3 radial = objHit - axisPoint;
+        if (LengthSquared(radial) <= 1e-12f)
+        {
+            float3 fallback;
+            CoordinateSystem(tangent, localNormal, fallback);
+        }
+        else
+            localNormal = normalize(radial);
     }
-    float3 fallbackAxis = p1.position - p0.position;
-    if (LengthSquared(tangentVector) <= 1e-12f)
-        tangentVector = LengthSquared(fallbackAxis) > 1e-12f ? fallbackAxis : float3(0.0f, 1.0f, 0.0f);
-    float3 tangent = normalize(tangentVector);
 
-    float3 localRayDirection = inst.rotation.conjugate().rotate(rayDirection) / inst.scale;
-    if (LengthSquared(localRayDirection) <= 1e-12f)
-        localRayDirection = float3(0.0f, 0.0f, 1.0f);
-    localRayDirection = normalize(localRayDirection);
+    float radius = lerp(leaf.r0, leaf.r1, localU);
+    float3 axisPoint = lerp(leaf.p0, leaf.p1, localU);
+    float3 objPosition = axisPoint + localNormal * max(radius, 0.0f);
+    hit.position = inst.transform + inst.rotation.rotate(objPosition * inst.scale);
 
-    float3 projectedTangent = tangent - localRayDirection * dot(tangent, localRayDirection);
+    float3 viewLocal = -normalize(objRd);
+    float3 facing = viewLocal - tangent * dot(viewLocal, tangent);
     float3 localBitangent;
-    if (LengthSquared(projectedTangent) > 1e-12f)
+    if (LengthSquared(facing) > 1e-12f)
     {
-        projectedTangent = normalize(projectedTangent);
-        localBitangent = normalize(cross(projectedTangent, localRayDirection));
+        facing = normalize(facing);
+        localBitangent = normalize(cross(tangent, facing));
     }
     else
     {
-        CoordinateSystem(localRayDirection, projectedTangent, localBitangent);
+        CoordinateSystem(tangent, facing, localBitangent);
     }
+    if (dot(localNormal, facing) < 0.0f)
+        localNormal = -localNormal;
 
-    float3 flatNormal = normalize(cross(tangent, localBitangent));
-    if (dot(flatNormal, localRayDirection) > 0.0f)
-    {
-        localBitangent = -localBitangent;
-        flatNormal = -flatNormal;
-    }
+    float h = clamp(dot(localNormal, localBitangent), -1.0f, 1.0f);
+    hit.uv = float2(lerp(leaf.u0, leaf.u1, localU), 0.5f * (h + 1.0f));
 
-    float theta = (saturate(uv.y) - 0.5f) * Pi;
-    float sinTheta, cosTheta;
-    sincos(theta, sinTheta, cosTheta);
-    float3 localNormal = normalize(cosTheta * flatNormal + sinTheta * localBitangent);
-    if (any(isnan(localNormal)))
-        localNormal = flatNormal;
     localBitangent = normalize(cross(localNormal, tangent));
     if (LengthSquared(localBitangent) <= 1e-12f)
-        localBitangent = normalize(cross(flatNormal, tangent));
+        localBitangent = normalize(cross(facing, tangent));
 
     float3 invScale = 1.0f / inst.scale;
     hit.normal = normalize(inst.rotation.rotate(localNormal * invScale));
@@ -956,6 +973,11 @@ bool TraceShadowRay<S : ISampler>(float3 origin, float3 direction, float tMax, i
             uint instance = q.CandidateInstanceID();
             if (IsLightInstance(instance))
                 continue;
+            if (IsCurveInstance(instance))
+            {
+                q.CommitNonOpaqueTriangleHit();
+                continue;
+            }
 
             uint primitive = q.CandidatePrimitiveIndex();
             float2 bary = q.CandidateTriangleBarycentrics();
@@ -974,23 +996,6 @@ bool TraceShadowRay<S : ISampler>(float3 origin, float3 direction, float tMax, i
 
             if (opacity == 1.0f || rng.sample() >= 1.0f - opacity) {
                 q.CommitNonOpaqueTriangleHit();
-            }
-        }
-        else
-        {
-            uint instance = q.CandidateInstanceID();
-            if (IsCurveInstance(instance))
-            {
-                uint primitive = q.CandidatePrimitiveIndex();
-                GSInstance inst = LoadSceneInstance(instance);
-                float3 objRo = inst.rotation.conjugate().rotate(ray.Origin - inst.transform) / inst.scale;
-                float3 objRd = inst.rotation.conjugate().rotate(ray.Direction) / inst.scale;
-                
-                float hitT, hitU, hitV;
-                if (EvaluateCurveIntersection(instance, primitive, objRo, objRd, q.RayTMin(), q.CommittedRayT(), hitT, hitU, hitV))
-                {
-                    q.CommitProceduralPrimitiveHit(hitT);
-                }
             }
         }
     }
@@ -1535,6 +1540,11 @@ void PathTrace<S : ISampler>(uint2 pix, uint subSample, inout S rng)
             if (q.CandidateType() == CANDIDATE_NON_OPAQUE_TRIANGLE)
             {
                 uint instance = q.CandidateInstanceID();
+                if (IsCurveInstance(instance))
+                {
+                    q.CommitNonOpaqueTriangleHit();
+                    continue;
+                }
                 uint primitive = q.CandidatePrimitiveIndex();
                 float2 bary = q.CandidateTriangleBarycentrics();
                 if (!EvaluateOpacityAlphaTest(instance, primitive, bary, rng))
@@ -1542,34 +1552,18 @@ void PathTrace<S : ISampler>(uint2 pix, uint subSample, inout S rng)
                     q.CommitNonOpaqueTriangleHit();
                 }
             }
-            else
+            else if (IsLightInstance(q.CandidateInstanceID()))
             {
                 uint instance = q.CandidateInstanceID();
-                uint primitive = q.CandidatePrimitiveIndex();
-                if (IsCurveInstance(instance))
+                GSLight gl = LoadSceneLight(GetLightIndex(instance));
+                float3 ro = q.CandidateObjectRayOrigin();
+                float3 rd = q.CandidateObjectRayDirection();
+                float t;
+                float2 localPos;
+                if (EvaluateLightIntersection(GSLightType(gl), ro, rd, q.RayTMin(), q.CommittedRayT(), t, localPos))
                 {
-                    float3 objRo = q.CandidateObjectRayOrigin();
-                    float3 objRd = q.CandidateObjectRayDirection();
-                    
-                    float hitT, hitU, hitV;
-                    if (EvaluateCurveIntersection(instance, primitive, objRo, objRd, q.RayTMin(), q.CommittedRayT(), hitT, hitU, hitV))
-                    {
-                        bestProceduralBary = float2(hitU, hitV);
-                        q.CommitProceduralPrimitiveHit(hitT);
-                    }
-                }
-                else if (IsLightInstance(instance))
-                {
-                    GSLight gl = LoadSceneLight(GetLightIndex(instance));
-                    float3 ro = q.CandidateObjectRayOrigin();
-                    float3 rd = q.CandidateObjectRayDirection();
-                    float t;
-                    float2 localPos;
-                    if (EvaluateLightIntersection(GSLightType(gl), ro, rd, q.RayTMin(), q.CommittedRayT(), t, localPos))
-                    {
-                        bestProceduralBary = localPos;
-                        q.CommitProceduralPrimitiveHit(t);
-                    }
+                    bestProceduralBary = localPos;
+                    q.CommitProceduralPrimitiveHit(t);
                 }
             }
         }
@@ -1839,198 +1833,3 @@ bool EvaluateLightIntersection(uint lightType, float3 ro, float3 rd, float rayTM
     localPosition = p;
     return true;
 }
-
-struct ProceduralHitAttributes
-{
-    float2 localPosition;
-};
-
-bool TryUpdateCurveHit(float t, float u, float v, float rayTMin, float rayTMax, inout float bestT, inout float bestU, inout float bestV)
-{
-    if (t < rayTMin || t > rayTMax || t >= bestT)
-        return false;
-    bestT = t;
-    bestU = u;
-    bestV = v;
-    return true;
-}
-
-float3 ProjectPerpendicularToRay(float3 v, float3 rd)
-{
-    return v - rd * (dot(v, rd) / max(dot(rd, rd), 1e-12f));
-}
-
-void SplitCubicBezier(float4 q0, float4 q1, float4 q2, float4 q3, float u,
-                      out float4 left0, out float4 left1, out float4 left2, out float4 left3,
-                      out float4 right0, out float4 right1, out float4 right2, out float4 right3)
-{
-    float4 q01 = lerp(q0, q1, u);
-    float4 q12 = lerp(q1, q2, u);
-    float4 q23 = lerp(q2, q3, u);
-    float4 q012 = lerp(q01, q12, u);
-    float4 q123 = lerp(q12, q23, u);
-    float4 q0123 = lerp(q012, q123, u);
-
-    left0 = q0;
-    left1 = q01;
-    left2 = q012;
-    left3 = q0123;
-    right0 = q0123;
-    right1 = q123;
-    right2 = q23;
-    right3 = q3;
-}
-
-void ExtractCubicBezierInterval(float4 q0, float4 q1, float4 q2, float4 q3, float u0, float u1,
-                                out float4 out0, out float4 out1, out float4 out2, out float4 out3)
-{
-    float4 l0, l1, l2, l3;
-    float4 r0, r1, r2, r3;
-    SplitCubicBezier(q0, q1, q2, q3, u1, l0, l1, l2, l3, r0, r1, r2, r3);
-    if (u0 <= 0.0f)
-    {
-        out0 = l0;
-        out1 = l1;
-        out2 = l2;
-        out3 = l3;
-        return;
-    }
-
-    float split = saturate(u0 / max(u1, 1e-7f));
-    SplitCubicBezier(l0, l1, l2, l3, split, r0, r1, r2, r3, out0, out1, out2, out3);
-}
-
-void TryIntersectFlatCurveLeaf(float3 ro, float3 rd, float4 q0, float4 q1, float4 q2, float4 q3,
-                               float u0, float u1, float rayTMin, float rayTMax, inout float bestT, inout float bestU, inout float bestV)
-{
-    if (max(max(q0.w, q1.w), max(q2.w, q3.w)) <= 0.0f)
-        return;
-
-    float3 p0 = ProjectPerpendicularToRay(q0.xyz - ro, rd);
-    float3 p3 = ProjectPerpendicularToRay(q3.xyz - ro, rd);
-    float3 h0 = ProjectPerpendicularToRay(q1.xyz - ro, rd);
-    float3 h1 = ProjectPerpendicularToRay(q2.xyz - ro, rd);
-
-    float startEdge = (h0.y - p0.y) * -p0.y + p0.x * (p0.x - h0.x);
-    if (startEdge < 0.0f)
-        return;
-
-    float endEdge = (h1.y - p3.y) * -p3.y + p3.x * (p3.x - h1.x);
-    if (endEdge < 0.0f)
-        return;
-
-    float3 segment = p3 - p0;
-    float segmentLen2 = dot(segment, segment);
-    if (segmentLen2 <= 1e-12f)
-        return;
-
-    float w = dot(-p0, segment) / segmentLen2;
-    float clampedW = saturate(w);
-    float4 q = EvaluateCubicBezier(q0, q1, q2, q3, clampedW);
-    float3 p = ProjectPerpendicularToRay(q.xyz - ro, rd);
-    float dist2 = dot(p, p);
-    if (dist2 > q.w * q.w)
-        return;
-
-    float t = dot(q.xyz - ro, rd) / max(dot(rd, rd), 1e-12f);
-    float side = p.x * segment.y - p.y * segment.x;
-    float v = 0.5f + (side > 0.0f ? 0.5f : -0.5f) * sqrt(dist2) / max(q.w, 1e-7f);
-    TryUpdateCurveHit(t, lerp(u0, u1, clampedW), saturate(v), rayTMin, rayTMax, bestT, bestU, bestV);
-}
-
-void TryIntersectFlatCurveSegment(float3 ro, float3 rd, float4 q0, float4 q1, float u0, float u1,
-                                  float rayTMin, float rayTMax, inout float bestT, inout float bestU, inout float bestV)
-{
-    TryIntersectFlatCurveLeaf(ro, rd, q0, lerp(q0, q1, 1.0f / 3.0f), lerp(q0, q1, 2.0f / 3.0f), q1,
-                              u0, u1, rayTMin, rayTMax, bestT, bestU, bestV);
-}
-
-int GetBezierSubdivisionDepth(float4 q0, float4 q1, float4 q2, float4 q3, float3 rd)
-{
-    static const int kCurveMaxSubdivisionDepth = 2;
-    float3 d0 = ProjectPerpendicularToRay(q0.xyz - 2.0f * q1.xyz + q2.xyz, rd);
-    float3 d1 = ProjectPerpendicularToRay(q1.xyz - 2.0f * q2.xyz + q3.xyz, rd);
-    float curvature = max(length(d0), length(d1));
-    float maxRadius = max(max(q0.w, q1.w), max(q2.w, q3.w));
-    float epsilon = max(maxRadius * 0.05f, 1e-5f);
-
-    int depth = 0;
-    [loop]
-    for (int i = 0; i < kCurveMaxSubdivisionDepth; ++i)
-    {
-        if (curvature <= epsilon)
-            break;
-        curvature *= 0.25f;
-        ++depth;
-    }
-    return depth;
-}
-
-void TryIntersectBezierCurve(float3 ro, float3 rd, GSCurveSegment segment,
-                             float4 q0, float4 q1, float4 q2, float4 q3,
-                             float rayTMin, float rayTMax, inout float bestT, inout float bestU, inout float bestV)
-{
-    float maxRadius = max(max(q0.w, q1.w), max(q2.w, q3.w));
-    if (maxRadius <= 0.0f)
-        return;
-
-    int depth = GetBezierSubdivisionDepth(q0, q1, q2, q3, rd);
-    uint leafCount = 1u << uint(depth);
-    float invLeafCount = 1.0f / float(leafCount);
-
-    [loop]
-    for (uint i = 0; i < leafCount; ++i)
-    {
-        float t0 = float(i) * invLeafCount;
-        float t1 = float(i + 1u) * invLeafCount;
-        float4 l0, l1, l2, l3;
-        ExtractCubicBezierInterval(q0, q1, q2, q3, t0, t1, l0, l1, l2, l3);
-        float u0 = lerp(segment.u0, segment.u1, t0);
-        float u1 = lerp(segment.u0, segment.u1, t1);
-        TryIntersectFlatCurveLeaf(ro, rd, l0, l1, l2, l3, u0, u1, rayTMin, rayTMax, bestT, bestU, bestV);
-    }
-}
-
-bool EvaluateCurveIntersection(uint instance, uint primitive, float3 ro, float3 rd, float rayTMin, float rayTMax, out float hitT, out float hitU, out float hitV)
-{
-    GSInstance inst = LoadSceneInstance(instance);
-    GSCurveSet curve = primitives.Load<GSCurveSet>(inst.resourceOffset);
-    GSCurveSegment segment = primitives.Load<GSCurveSegment>(curve.segmentOffset + primitive * sizeof(GSCurveSegment));
-    GSCurvePoint p0 = primitives.Load<GSCurvePoint>(curve.pointOffset + segment.p0 * sizeof(GSCurvePoint));
-    GSCurvePoint p1 = primitives.Load<GSCurvePoint>(curve.pointOffset + segment.p1 * sizeof(GSCurvePoint));
-
-    float bestT = rayTMax;
-    float bestU = segment.u0;
-    float bestV = 0.5f;
-
-    if (IsBezierCurveSegment(curve, segment))
-    {
-        float4 q0 = float4(p0.position, p0.radius);
-        float4 q1 = LoadCurveControl(curve, segment.p0 + 1);
-        float4 q2 = LoadCurveControl(curve, segment.p0 + 2);
-        float4 q3 = float4(p1.position, p1.radius);
-        TryIntersectBezierCurve(ro, rd, segment, q0, q1, q2, q3, rayTMin, rayTMax, bestT, bestU, bestV);
-    }
-    else
-    {
-        TryIntersectFlatCurveSegment(ro, rd,
-                                     float4(p0.position, p0.radius),
-                                     float4(p1.position, p1.radius),
-                                     segment.u0, segment.u1, rayTMin, rayTMax, bestT, bestU, bestV);
-    }
-
-    if (bestT < rayTMax)
-    {
-        hitT = bestT;
-        hitU = bestU;
-        hitV = bestV;
-        return true;
-    }
-    return false;
-}
-;
-
-
-
-
-

--- a/Source/Renderer/Shaders/EVSCurveDraw.slang
+++ b/Source/Renderer/Shaders/EVSCurveDraw.slang
@@ -1,0 +1,70 @@
+// Vertex shader for DOTS curve triangle MDI draws. The static Primitive buffer is
+// bound as a UINT32 index buffer; SV_VertexID is the curve-local vertex index.
+// Leaf data reconstructs a radial normal / strand UV for the shared EPSGBuffer.
+#include "ICommon.slang"
+
+uniform UBO globalParams;
+[[vk_binding(1, 0)]] StructuredBuffer<GSInstance> instances;
+[[vk_binding(2, 0)]] ByteAddressBuffer primitive;
+[[vk_binding(6, 0)]] StructuredBuffer<uint> drawInstanceIDs;
+
+GSCurveLeaf LoadCurveLeaf(GSCurveSet curve, uint leafIndex)
+{
+    return primitive.Load<GSCurveLeaf>(curve.leafOffset + leafIndex * sizeof(GSCurveLeaf));
+}
+
+[shader("vertex")]
+V2F main(uint vertexID: SV_VertexID, uint drawID: SV_DrawIndex)
+{
+    uint instanceID = drawInstanceIDs[drawID];
+    GSInstance inst = instances[instanceID];
+    GSCurveSet curve = primitive.Load<GSCurveSet>(inst.resourceOffset);
+    GSCurveDOTSVertex vtx = primitive.Load<GSCurveDOTSVertex>(curve.vtxOffset + vertexID * sizeof(GSCurveDOTSVertex));
+
+    uint leafIndex = vertexID / 8u;
+    GSCurveLeaf leaf = LoadCurveLeaf(curve, leafIndex);
+    float3 axis = leaf.p1 - leaf.p0;
+    float axisLen2 = dot(axis, axis);
+    float3 tangent = axisLen2 > 1e-12f ? normalize(axis) : float3(0.0f, 1.0f, 0.0f);
+    float localU = axisLen2 > 1e-12f ? saturate(dot(vtx.position - leaf.p0, axis) / axisLen2) : 0.0f;
+    float3 axisPoint = lerp(leaf.p0, leaf.p1, localU);
+    float3 radial = vtx.position - axisPoint;
+
+    float3 normal;
+    float3 bitangent;
+    if (dot(radial, radial) > 1e-12f)
+    {
+        normal = normalize(radial);
+        bitangent = cross(normal, tangent);
+        if (dot(bitangent, bitangent) <= 1e-12f)
+            CoordinateSystem(tangent, normal, bitangent);
+        else
+            bitangent = normalize(bitangent);
+    }
+    else
+    {
+        CoordinateSystem(tangent, normal, bitangent);
+    }
+
+    // DOTS leaf packs two orthogonal quads; odd corners of each quad are the -side edge.
+    uint corner = vertexID % 8u;
+    float h = (corner == 2u || corner == 3u || corner == 6u || corner == 7u) ? -1.0f : 1.0f;
+
+    float3 position = inst.rotation.rotate(vtx.position) * inst.scale + inst.transform;
+    float3 invScale = 1.0f / inst.scale;
+    normal = normalize(inst.rotation.rotate(normal * invScale));
+    tangent = normalize(inst.rotation.rotate(tangent * invScale));
+    bitangent = normalize(inst.rotation.rotate(bitangent * invScale));
+
+    V2F v2f;
+    v2f.pos = mul(mul(globalParams.proj, globalParams.view), float4(position, 1.0));
+    v2f.normal = normal;
+    v2f.tangent = tangent;
+    v2f.bitangent = bitangent;
+    v2f.bitangentSign = 1.0f;
+    v2f.uv = float2(lerp(leaf.u0, leaf.u1, localU), 0.5f * (h + 1.0f));
+    v2f.meshlet = 0u;
+    v2f.materialIndex = inst.materialIndex;
+    v2f.instanceID = instanceID;
+    return v2f;
+}

--- a/Source/Renderer/Shaders/EVSCurveMotionDraw.slang
+++ b/Source/Renderer/Shaders/EVSCurveMotionDraw.slang
@@ -1,0 +1,35 @@
+// Motion-vector VS for TRS-animated DOTS curve instances.
+#include "ICommon.slang"
+
+uniform UBO globalParams;
+[[vk_binding(1, 0)]] StructuredBuffer<GSInstance> instances;
+[[vk_binding(2, 0)]] ByteAddressBuffer primitive;
+[[vk_binding(3, 0)]] StructuredBuffer<uint> drawInstanceIDs;
+
+public struct MotionV2F
+{
+    public float4 pos : SV_POSITION;
+    public float4 currClip : CURRCLIP;
+    public float4 prevClip : PREVCLIP;
+};
+
+[shader("vertex")]
+MotionV2F main(uint vertexID: SV_VertexID, uint drawID: SV_DrawIndex)
+{
+    uint instanceID = drawInstanceIDs[drawID];
+    GSInstance inst = instances[instanceID];
+    GSCurveSet curve = primitive.Load<GSCurveSet>(inst.resourceOffset);
+    GSCurveDOTSVertex vtx = primitive.Load<GSCurveDOTSVertex>(curve.vtxOffset + vertexID * sizeof(GSCurveDOTSVertex));
+
+    float3 currPos = inst.rotation.rotate(vtx.position) * inst.scale + inst.transform;
+    float3 prevPos = inst.prevRotation.rotate(vtx.position) * inst.prevScale + inst.prevTransform;
+
+    float4x4 viewProj = mul(globalParams.proj, globalParams.view);
+    float4 currClip = mul(viewProj, float4(currPos, 1.0));
+    float4 prevClip = mul(globalParams.previousViewProj, float4(prevPos, 1.0));
+    MotionV2F v2f;
+    v2f.pos = currClip;
+    v2f.currClip = currClip;
+    v2f.prevClip = prevClip;
+    return v2f;
+}

--- a/Source/Renderer/Shaders/ICommon.slang
+++ b/Source/Renderer/Shaders/ICommon.slang
@@ -128,21 +128,24 @@ public bool GSInstanceIsDynamic(GSInstance i) { return (i.type & kGSInstanceFlag
 public bool GSInstanceHasMotion(GSInstance i, uint32_t frame) { return i.motionFrame == frame; }
 public struct GSCurveSet
 {
-    public uint32_t pointOffset;
-    public uint32_t pointCount;
-    public uint32_t segmentOffset;
-    public uint32_t segmentCount;
-    public uint32_t aabbOffset;
+    public uint32_t vtxOffset;
+    public uint32_t vtxCount;
+    public uint32_t idxOffset;
+    public uint32_t idxCount;
+    public uint32_t leafOffset;
+    public uint32_t leafCount;
 };
-public struct GSCurvePoint
+public struct GSCurveDOTSVertex
 {
     public float3 position;
-    public float radius;
+    public float pad;
 };
-public struct GSCurveSegment
+public struct GSCurveLeaf
 {
-    public uint32_t p0;
-    public uint32_t p1;
+    public float3 p0;
+    public float r0;
+    public float3 p1;
+    public float r1;
     public float u0;
     public float u1;
 };

--- a/ThirdParty/cgltf/cgltf.h
+++ b/ThirdParty/cgltf/cgltf.h
@@ -6599,34 +6599,8 @@ static int cgltf_parse_json_node(cgltf_options* options, jsmntok_t const* tokens
 				}
 				else if (cgltf_json_strcmp(tokens+i, json_chunk, "EXT_foundation_curves") == 0)
 				{
-					++i;
-
-					CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
-
-					int data_size = tokens[i].size;
-					++i;
-
-					for (int m = 0; m < data_size; ++m)
-					{
-						CGLTF_CHECK_KEY(tokens[i]);
-
-						if (cgltf_json_strcmp(tokens + i, json_chunk, "curve") == 0)
-						{
-							++i;
-							CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_PRIMITIVE);
-							out_node->curve = CGLTF_PTRINDEX(cgltf_curve, cgltf_json_to_int(tokens + i, json_chunk));
-							++i;
-						}
-						else
-						{
-							i = cgltf_skip_json(tokens, i + 1);
-						}
-
-						if (i < 0)
-						{
-							return i;
-						}
-					}
+					/* Deprecated: curves are now standard LINES + _RADIUS mesh primitives. */
+					i = cgltf_skip_json(tokens, i + 1);
 				}
 				else if (cgltf_json_strcmp(tokens + i, json_chunk, "EXT_mesh_gpu_instancing") == 0)
 				{
@@ -7649,31 +7623,8 @@ static int cgltf_parse_json_root(cgltf_options* options, jsmntok_t const* tokens
 				}
 				else if (cgltf_json_strcmp(tokens+i, json_chunk, "EXT_foundation_curves") == 0)
 				{
-					++i;
-
-					CGLTF_CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
-
-					int data_size = tokens[i].size;
-					++i;
-
-					for (int m = 0; m < data_size; ++m)
-					{
-						CGLTF_CHECK_KEY(tokens[i]);
-
-						if (cgltf_json_strcmp(tokens + i, json_chunk, "curves") == 0)
-						{
-							i = cgltf_parse_json_curves(options, tokens, i + 1, json_chunk, out_data);
-						}
-						else
-						{
-							i = cgltf_skip_json(tokens, i + 1);
-						}
-
-						if (i < 0)
-						{
-							return i;
-						}
-					}
+					/* Deprecated: curves are now standard LINES + _RADIUS mesh primitives. */
+					i = cgltf_skip_json(tokens, i + 1);
 				}
 				else if (cgltf_json_strcmp(tokens+i, json_chunk, "EXT_foundation_animation") == 0)
 				{


### PR DESCRIPTION
Or, "Disjoint Orthogonal Triangle Strips". Taken from https://github.com/NVIDIA-RTX/RTXCR, not sure if anyone but NV calls this technique that way.

<img width="1999" height="1261" alt="image" src="https://github.com/user-attachments/assets/be04d323-5e07-419f-bc8f-3bd36ea94880" />

See also:
- [Render Path-Traced Hair in Real Time with NVIDIA GeForce RTX 50 Series GPUs](https://github.com/mos9527/Foundation/pull/14)
- [Strand-based hair and fur in “Indiana Jones and the Great Circle”](https://advances.realtimerendering.com/s2025/content/Strand%20Hair%20in%20IJGC%20-%20Final%20Slides%20(Post-Conference).pdf)
- [Path-Traced Hair Rendering in Indiana Jones and the Great Circle](https://vulkan.org/user/pages/09.events/vulkanised-2026/1145-Jiho-Choi-NVIDIA%201.pdf)

TODO Curve caps (maybe not..), LSS impl (see NV blog post) and Rasterizer LOD