### PR TITLE
Emissive Triangles in NEE/LightBVH

### DIFF
--- a/Editor/Context.hpp
+++ b/Editor/Context.hpp
@@ -56,7 +56,7 @@ struct FContext
     struct RendererSettings
     {
         int defaultRenderer{0}; // 0: Progressive PT, 1: Raster, 2: Realtime PT (RTPT)
-        float energyClampOverride{2.0f}; // Applies to default PT, Fast preset
+        float energyClampOverride{1.0f}; // Applies to default PT, Fast preset
         float renderScale{1.0f}; // 0.25 .. 1.0
     } rendererSettings;
 };

--- a/Editor/EditorUI.cpp
+++ b/Editor/EditorUI.cpp
@@ -3010,19 +3010,19 @@ void FRunningImGui()
             if (ImModalButton(PSI_CODE " Direct", 0, 4))
             {
                 GEditor.shaderGlobals.ptMaxBounces = 0;
-                GEditor.shaderGlobals.ptFireflyClamp = GContext->rendererSettings.energyClampOverride; // Default 2.0
+                GEditor.shaderGlobals.ptFireflyClamp = GContext->rendererSettings.energyClampOverride; // Default 1.0
                 GEditor.shaderGlobals.ptAccumulatedFrames = 0;
             }
             if (ImModalButton(PSI_BOLT " Fast", 1, 4))
             {
                 GEditor.shaderGlobals.ptMaxBounces = 4;
-                GEditor.shaderGlobals.ptFireflyClamp = GContext->rendererSettings.energyClampOverride; // Default 2.0
+                GEditor.shaderGlobals.ptFireflyClamp = GContext->rendererSettings.energyClampOverride; // Default 1.0
                 GEditor.shaderGlobals.ptAccumulatedFrames = 0;
             }
             if (ImModalButton(PSI_FIRE " Full", 2, 4))
             {
                 GEditor.shaderGlobals.ptMaxBounces = 32;
-                GEditor.shaderGlobals.ptFireflyClamp = GContext->rendererSettings.energyClampOverride; // Default 2.0
+                GEditor.shaderGlobals.ptFireflyClamp = GContext->rendererSettings.energyClampOverride; // Default 1.0
                 GEditor.shaderGlobals.ptAccumulatedFrames = 0;
             }
             if (ImModalButton(PSI_BEAKER " Über", 3, 4))

--- a/Editor/SDLMain.cpp
+++ b/Editor/SDLMain.cpp
@@ -80,7 +80,7 @@ int main(int argc, char** argv)
 
     // Renderer Settings
     // --energy-clamp / -e: specify energy clamp value
-    cmdl({"-e", "--energy-clamp"}, 2.0f) >> GContext->rendererSettings.energyClampOverride;
+    cmdl({"-e", "--energy-clamp"}, 1.0f) >> GContext->rendererSettings.energyClampOverride;
     // --renderer / -r: specify default renderer (0: Progressive PT, 1: RASTER, 2: Realtime PT / RTPT)
     cmdl({"-r", "--renderer"}, 0) >> GContext->rendererSettings.defaultRenderer;
     // --render-scale / -s: initial viewport render resolution scale

--- a/Editor/Scene/Scene.cpp
+++ b/Editor/Scene/Scene.cpp
@@ -474,7 +474,10 @@ void ValidateSceneTables(FSceneHeader const& header, FSceneTables const& tables)
         ValidateBlobArray<FLODGroup>(header, mesh.dagGroups, "mesh.dagGroups");
         ValidateBlobArray<FMeshlet>(header, mesh.dagMeshlets, "mesh.dagMeshlets");
         ValidateBlobArray<uint8_t>(header, mesh.dagMeshletTri, "mesh.dagMeshletTri");
-        ValidateBlobArray<uint32_t>(header, mesh.dagMeshletVtx, "mesh.dagMeshletVtx");        
+        ValidateBlobArray<uint32_t>(header, mesh.dagMeshletVtx, "mesh.dagMeshletVtx");
+        ValidateBlobArray<FEmissiveMeshlet>(header, mesh.emissiveMeshlets, "mesh.emissiveMeshlets");
+        ValidateBlobArray<GSAlias>(header, mesh.emissiveAliases, "mesh.emissiveAliases");
+        ValidateBlobArray<uint32_t>(header, mesh.emissivePrimitiveMap, "mesh.emissivePrimitiveMap");
         if (mesh.skeleton.IsNil())
         {
             CHECK_MSG(mesh.skinBinding.decodedSize == 0 && mesh.skinBinding.count == 0,
@@ -1836,6 +1839,9 @@ void BuildMeshBlobJobs(FSerializedMesh& desc, Vector<FBlobJob>& blobJobs, FImpor
     desc.dagMeshlets = {};
     desc.dagMeshletTri = {};
     desc.dagMeshletVtx = {};
+    desc.emissiveMeshlets = {};
+    desc.emissiveAliases = {};
+    desc.emissivePrimitiveMap = {};
     desc.skinBinding = {};
     desc.skeleton = skeleton;
 
@@ -1852,6 +1858,9 @@ void BuildMeshBlobJobs(FSerializedMesh& desc, Vector<FBlobJob>& blobJobs, FImpor
     AppendArrayBlobJob(blobJobs, mesh.dag.meshlets, FBlobCodec::LZ4, desc.dagMeshlets);
     AppendArrayBlobJob(blobJobs, mesh.dag.meshletTri, FBlobCodec::LZ4, desc.dagMeshletTri);
     AppendArrayBlobJob(blobJobs, mesh.dag.meshletVtx, FBlobCodec::LZ4, desc.dagMeshletVtx);
+    AppendArrayBlobJob(blobJobs, mesh.dag.emissiveMeshlets, FBlobCodec::LZ4, desc.emissiveMeshlets);
+    AppendArrayBlobJob(blobJobs, mesh.dag.emissiveAliases, FBlobCodec::LZ4, desc.emissiveAliases);
+    AppendArrayBlobJob(blobJobs, mesh.dag.emissivePrimitiveMap, FBlobCodec::LZ4, desc.emissivePrimitiveMap);
     AppendArrayBlobJob(blobJobs, mesh.skin, FBlobCodec::LZ4, desc.skinBinding);
 }
 
@@ -1958,6 +1967,7 @@ GPUSceneDesc FImportedScene::CalculateGPUSceneDesc(Foundation::RHI::RHIDeviceCap
     desc.materialBudget = RingGPUSceneBudget(GetMaterials().size());
     desc.lightBudget = RingGPUSceneBudget(GetLights().size());
     size_t skinnedInstanceCount = 0;
+    size_t emissiveClusterCount = 0;
     size_t dynamicBytes = 0;
     for (FInstance const& instance : GetInstances())
     {
@@ -1968,7 +1978,10 @@ GPUSceneDesc FImportedScene::CalculateGPUSceneDesc(Foundation::RHI::RHIDeviceCap
             continue;
         FSerializedMesh const& mesh = GetMeshes()[static_cast<size_t>(meshIndex)];
         if (mesh.skeleton.IsNil())
+        {
+            emissiveClusterCount += mesh.emissiveMeshlets.count;
             continue;
+        }
         CHECK_MSG(!mesh.lods.empty(), "Skinned mesh has no LOD0");
         uint64_t bytes = sizeof(GSMesh) + static_cast<uint64_t>(mesh.vertexCount) * sizeof(FQVertex) +
             static_cast<uint64_t>(mesh.lods[0].indexCount) * sizeof(uint32_t);
@@ -1976,6 +1989,7 @@ GPUSceneDesc FImportedScene::CalculateGPUSceneDesc(Foundation::RHI::RHIDeviceCap
         ++skinnedInstanceCount;
     }
     desc.dynamicGeometryBudget = ByteGPUSceneBudget(dynamicBytes, 0, size_t(16));
+    desc.emissiveClusterBudget = RingGPUSceneBudget(emissiveClusterCount);
     desc.geometryBudget =
         CountGPUSceneBudget(rigidMeshCount + GetCurves().size() + skinnedInstanceCount);
     desc.dynamicStagingFramesInFlight = kGPUSceneRingFrameSlack;

--- a/Editor/Scene/Scene.cpp
+++ b/Editor/Scene/Scene.cpp
@@ -1193,9 +1193,11 @@ void BuildGLTFSerializedScene(RHIApplication const& app, JobSystem* jobs, String
             material.normalTexture = assignTextureId(mat->normal_texture);
         if (mat->emissive_texture.texture)
             material.emissiveTexture = assignTextureId(mat->emissive_texture, kTextureInSRGB);
-        material.emissiveFactor = {mat->emissive_factor[0], mat->emissive_factor[1], mat->emissive_factor[2], 1.0f};
-        if (mat->emissive_strength.emissive_strength)
-            material.emissiveFactor *= mat->emissive_strength.emissive_strength;
+        float emissiveStrength = mat->has_emissive_strength
+            ? mat->emissive_strength.emissive_strength
+            : 1.0f;
+        material.emissiveFactor = {
+            mat->emissive_factor[0], mat->emissive_factor[1], mat->emissive_factor[2], emissiveStrength};
         material.transmissionFactor = mat->has_transmission ? mat->transmission.transmission_factor : 0.0f;
         if (mat->has_transmission && mat->transmission.transmission_texture.texture)
             material.transmissionTexture = assignTextureId(mat->transmission.transmission_texture);

--- a/Editor/Scene/Scene.cpp
+++ b/Editor/Scene/Scene.cpp
@@ -478,6 +478,10 @@ void ValidateSceneTables(FSceneHeader const& header, FSceneTables const& tables)
         ValidateBlobArray<FEmissiveMeshlet>(header, mesh.emissiveMeshlets, "mesh.emissiveMeshlets");
         ValidateBlobArray<GSAlias>(header, mesh.emissiveAliases, "mesh.emissiveAliases");
         ValidateBlobArray<uint32_t>(header, mesh.emissivePrimitiveMap, "mesh.emissivePrimitiveMap");
+        CHECK_MSG(mesh.emissiveMeshlets.count == 0u
+                      ? mesh.emissivePrimitiveMap.count == 0u
+                      : (!mesh.lods.empty() && mesh.emissivePrimitiveMap.count == mesh.lods[0].indexCount / 3u),
+                  "FScene emissive primitive map does not match emissive meshlets");
         if (mesh.skeleton.IsNil())
         {
             CHECK_MSG(mesh.skinBinding.decodedSize == 0 && mesh.skinBinding.count == 0,

--- a/Editor/Scene/Scene.hpp
+++ b/Editor/Scene/Scene.hpp
@@ -164,7 +164,7 @@ struct FSceneGlobals
     uint32_t viewLutHdrIndex{1u};
 };
 static constexpr uint32_t kSceneMagic = fourCC("FSCN");
-static constexpr uint32_t kSceneVersion = 25;
+static constexpr uint32_t kSceneVersion = 26;
 
 // Stringpool entry
 struct FStringEntry
@@ -234,6 +234,9 @@ inline void FSerialize(FWriter& writer, FSerializedMesh const& mesh)
     FSerialize(writer, mesh.dagMeshlets);
     FSerialize(writer, mesh.dagMeshletTri);
     FSerialize(writer, mesh.dagMeshletVtx);
+    FSerialize(writer, mesh.emissiveMeshlets);
+    FSerialize(writer, mesh.emissiveAliases);
+    FSerialize(writer, mesh.emissivePrimitiveMap);
     FSerialize(writer, mesh.skinBinding);
     FSerialize(writer, mesh.skeleton);
 }
@@ -250,6 +253,9 @@ inline void FDeserialize(FReader& reader, FSerializedMesh& mesh)
     FDeserialize(reader, mesh.dagMeshlets);
     FDeserialize(reader, mesh.dagMeshletTri);
     FDeserialize(reader, mesh.dagMeshletVtx);
+    FDeserialize(reader, mesh.emissiveMeshlets);
+    FDeserialize(reader, mesh.emissiveAliases);
+    FDeserialize(reader, mesh.emissivePrimitiveMap);
     FDeserialize(reader, mesh.skinBinding);
     FDeserialize(reader, mesh.skeleton);
 }

--- a/Source/Renderer/GPUScene.cpp
+++ b/Source/Renderer/GPUScene.cpp
@@ -10,7 +10,8 @@
 #include <bit>
 #include <condition_variable>
 #include <cstddef>
-#include "LightBVH.hpp"
+    #include <numbers>
+    #include "LightBVH.hpp"
 #include "Precompute.hpp"
 #include "Renderer.hpp"
 #include "Tables/GGX.hpp"
@@ -132,6 +133,7 @@ struct GPUSceneImpl
         /* --- */
         GSMesh mesh{};
         GSCurveSet curve{};
+        Vector<FEmissiveMeshlet> emissiveMeshlets{GLOBAL_ALLOC};
         bool dynamic{false};
         bool isGpu{false};
         bool dynamicIsBuilt{false};
@@ -188,6 +190,7 @@ struct GPUSceneImpl
     // Light BVH
     bool mLightBVHNeedsRefit{false};
     UploadGPURingBuffer<GSLight> mLightBuffer;
+    UploadGPURingBuffer<GSEmissiveCluster> mEmissiveClusterBuffer;
     UploadGPURingBuffer<GSLightBVHNode> mLightBVHNodeBuffer;
     Vector<LightBVHRefitLevel> mLightBVHRefitLevels;
     UploadGPURingBuffer<uint32_t> mLightBVHLightIndexBuffer;
@@ -437,7 +440,8 @@ size_t GPUScene::CalculateMeshPrimitiveSize(FSerializedMesh const& src)
 {
     uint64_t lod0Size = src.lods.empty() ? 0 : src.lods[0].indices.decodedSize;
     return sizeof(GSMesh) + src.vertices.decodedSize + lod0Size + src.dagGroups.decodedSize +
-        src.dagMeshlets.decodedSize + src.dagMeshletVtx.decodedSize + src.dagMeshletTri.decodedSize;
+        src.dagMeshlets.decodedSize + src.dagMeshletVtx.decodedSize + src.dagMeshletTri.decodedSize +
+        src.emissiveMeshlets.decodedSize + src.emissiveAliases.decodedSize + src.emissivePrimitiveMap.decodedSize;
 }
 
 size_t GPUScene::CalculateCurvePrimitiveSize(FSerializedCurve const& src)
@@ -465,9 +469,12 @@ GPUSceneImpl::GPUSceneImpl(GPUScene& owner, RHIDevice* device, JobSystem* jobs, 
                            GPUSceneDesc const& desc, AllocatorStack* frameScratch) :
     owner(owner), mDevice(device), mJobs(jobs), mAllocator(allocator), mStackAlloc(frameScratch),
     mInstanceBuffer(device, desc.instanceBudget), mMaterialBuffer(device, desc.materialBudget),
-    mLightBuffer(device, desc.lightBudget), mLightBVHNodeBuffer(device, desc.lightBudget * 2u),
-    mLightBVHLightIndexBuffer(device, desc.lightBudget), mLightBVHBitmaskBuffer(device, desc.lightBudget),
-    mLightBVHGlobalIndexBuffer(device, desc.lightBudget), mLightBVHNodeIndexBuffer(device, desc.lightBudget * 2u),
+    mLightBuffer(device, desc.lightBudget), mEmissiveClusterBuffer(device, desc.emissiveClusterBudget),
+    mLightBVHNodeBuffer(device, (desc.lightBudget + desc.emissiveClusterBudget) * 2u),
+    mLightBVHLightIndexBuffer(device, desc.lightBudget + desc.emissiveClusterBudget),
+    mLightBVHBitmaskBuffer(device, desc.lightBudget + desc.emissiveClusterBudget),
+    mLightBVHGlobalIndexBuffer(device, desc.lightBudget),
+    mLightBVHNodeIndexBuffer(device, (desc.lightBudget + desc.emissiveClusterBudget) * 2u),
     mTexture2DPool(device, allocator, {.maxBindings = desc.texturesBudget}),
     mTexture3DPool(device, allocator,
                    {.maxBindings = kGPUScenePersistentTexture3DBindings + kGPUSceneTextureBindingSlack}),
@@ -486,6 +493,16 @@ GPUSceneImpl::GPUSceneImpl(GPUScene& owner, RHIDevice* device, JobSystem* jobs, 
     CHECK(mJobs != nullptr);
     CHECK(mAllocator != nullptr);
     static_assert(sizeof(GSLightBVHNode) == 48);
+#ifndef NDEBUG
+    static bool const samplingSelfTestsPassed = [&]
+    {
+        String error;
+        CHECK_MSG(AliasTableRunSelfTests(mAllocator, &error), "Alias table self-test failed: {}", error);
+        CHECK_MSG(LightBVHRunBuilderSelfTests(mAllocator, &error), "Light BVH self-test failed: {}", error);
+        return true;
+    }();
+    (void)samplingSelfTestsPassed;
+#endif
     mGeometry.reserve(desc.geometryBudget);
     mBLASes.reserve(desc.geometryBudget);
     mBLASBuffers.reserve(desc.geometryBudget);
@@ -842,22 +859,70 @@ GPUScene::UpdateResult GPUSceneImpl::EndScene(GPUSceneTables& tables)
         uint32_t const type = g->type | static_cast<uint32_t>(flags);
         inst.resourceOffset = resourceOffset;
         inst.type = type;
+        inst.emissiveClusterOffset = UINT32_MAX;
+    }
+    Allocator* buildAlloc = mStackAlloc ? static_cast<Allocator*>(mStackAlloc) : mAllocator;
+    Vector<GSEmissiveCluster> emissiveClusters(buildAlloc);
+    for (uint32_t instanceIndex = 0; instanceIndex < tables.instances.size(); ++instanceIndex)
+    {
+        GSInstance& inst = tables.instances[instanceIndex];
+        if ((inst.type & kGSInstanceTypeMask) != kGSInstanceTypeMesh ||
+            (inst.type & to_integer(GSInstanceFlagsBits::Dynamic)) != 0u ||
+            inst.materialIndex >= tables.materials.size())
+            continue;
+        GSMaterial const& material = tables.materials[inst.materialIndex];
+        float emissionWeight =
+            (std::abs(material.emissiveFactor.x) + std::abs(material.emissiveFactor.y) +
+             std::abs(material.emissiveFactor.z)) /
+            3.0f;
+        if (emissionWeight <= 0.0f)
+            continue;
+        Geometry* geometry = ResolveGeometry({inst.resourceIndex, 0u});
+        if (!geometry || geometry->emissiveMeshlets.empty())
+            continue;
+
+        inst.emissiveClusterOffset = static_cast<uint32_t>(emissiveClusters.size());
+        float3 scaleAbs = abs(inst.scale);
+        float areaScale = std::max(scaleAbs.x * scaleAbs.y,
+                                   std::max(scaleAbs.y * scaleAbs.z, scaleAbs.z * scaleAbs.x));
+        for (FEmissiveMeshlet const& emitter : geometry->emissiveMeshlets)
+        {
+            GSEmissiveCluster& cluster = emissiveClusters.emplace_back();
+            cluster.instanceIndex = instanceIndex;
+            cluster.meshletIndex = emitter.meshletIndex;
+            cluster.aliasOffset = geometry->mesh.emissiveAliases.offset + emitter.aliasOffset * sizeof(GSAlias);
+            cluster.triCount = emitter.triCount;
+            cluster.flux = emissionWeight * emitter.area * areaScale * (2.0f * std::numbers::pi_v<float>);
+            float3 center = inst.rotation * emitter.center;
+            cluster.origin = center * inst.scale + inst.transform;
+            cluster.extent = emitter.radius * scaleAbs;
+        }
+    }
+    res.emissiveClustersHash = FNV1a64(Span<GSEmissiveCluster const>(emissiveClusters));
+    if (owner.mLastUpdateResult.emissiveClustersHash == res.emissiveClustersHash)
+        res.emissiveClusters = owner.mLastUpdateResult.emissiveClusters;
+    else if (!emissiveClusters.empty())
+    {
+        auto [ptr, offset] = mEmissiveClusterBuffer.Allocate(static_cast<uint32_t>(emissiveClusters.size()));
+        std::memcpy(ptr, emissiveClusters.data(), emissiveClusters.size() * sizeof(GSEmissiveCluster));
+        res.emissiveClusters = {offset, static_cast<uint32_t>(emissiveClusters.size())};
     }
     owner.mCommittedInstances.assign(tables.instances.begin(), tables.instances.end());
     owner.mCommittedMaterials.assign(tables.materials.begin(), tables.materials.end());
     owner.mCommittedLights.assign(tables.lights.begin(), tables.lights.end());
     // Light BVH update
-    if (owner.mLastUpdateResult.lightsHash == res.lightsHash)
+    if (owner.mLastUpdateResult.lightsHash == res.lightsHash &&
+        owner.mLastUpdateResult.emissiveClustersHash == res.emissiveClustersHash)
         res.lightBVH = owner.mLastUpdateResult.lightBVH, mLightBVHNeedsRefit = false;
     else
     {
-        mLightBVHNeedsRefit = true;
+        mLightBVHNeedsRefit = emissiveClusters.empty();
         LightBVHOptions options{};
-        LightBVHBuild bvh = BuildLightBVH(tables.lights, options, mStackAlloc ? mStackAlloc : mAllocator);
+        LightBVHBuild bvh = BuildLightBVH(tables.lights, emissiveClusters, options, buildAlloc);
 #ifndef NDEBUG
         String validationError;
-        CHECK_MSG(ValidateLightBVH(bvh, tables.lights, &validationError), "Light BVH validation failed: {}",
-                  validationError);
+        CHECK_MSG(ValidateLightBVH(bvh, tables.lights, emissiveClusters, &validationError),
+                  "Light BVH validation failed: {}", validationError);
 #endif
         UpdateResult::LightBVH& lightBVH = res.lightBVH;
         lightBVH.valid = bvh.valid;
@@ -918,6 +983,7 @@ void GPUScene::UpdateUBO(RendererUBO& globals) const
     globals.instances = mLastUpdateResult.instances;
     globals.materials = mLastUpdateResult.materials;
     globals.lights = mLastUpdateResult.lights;
+    globals.emissiveClusters = mLastUpdateResult.emissiveClusters;
     globals.lightBVHNodes = mLastUpdateResult.lightBVH.nodes;
     globals.lightBVHLightIndices = mLastUpdateResult.lightBVH.lightIndices;
     globals.firstLightBVHBitmask = mLastUpdateResult.lightBVH.bitmasks.offset;
@@ -966,6 +1032,7 @@ void GPUSceneImpl::DbgGetMemoryStatistics(Vector<MemoryStat>& outStats) const
     size_t instanceBytes = AddRingBufferSize(mInstanceBuffer);
     size_t materialBytes = AddRingBufferSize(mMaterialBuffer);
     size_t lightBytes = AddRingBufferSize(mLightBuffer);
+    size_t emissiveClusterBytes = AddRingBufferSize(mEmissiveClusterBuffer);
     size_t lightBVHNodeBytes = AddRingBufferSize(mLightBVHNodeBuffer);
     size_t lightBVHIndexBytes = AddRingBufferSize(mLightBVHLightIndexBuffer);
     size_t lightBVHBitmaskBytes = AddRingBufferSize(mLightBVHBitmaskBuffer);
@@ -992,8 +1059,8 @@ void GPUSceneImpl::DbgGetMemoryStatistics(Vector<MemoryStat>& outStats) const
     outStats.push_back({"Instance Buffer (Buffer)", instanceBytes});
     outStats.push_back({"TLAS Instance Buffer (Buffer)", tlasInstanceBytes});
     outStats.push_back({"Dynamic Upload Buffers (Buffer)",
-                        materialBytes + lightBytes + lightBVHNodeBytes + lightBVHIndexBytes + lightBVHBitmaskBytes +
-                            lightBVHGlobalBytes + lightBVHNodeIndexBytes});
+                        materialBytes + lightBytes + emissiveClusterBytes + lightBVHNodeBytes + lightBVHIndexBytes +
+                            lightBVHBitmaskBytes + lightBVHGlobalBytes + lightBVHNodeIndexBytes});
     outStats.push_back({"Mesh BLAS (Buffer)", blasBytes});
     outStats.push_back({"Curve BLAS (Buffer)", curveBLASBytes});
     outStats.push_back({"TLAS (Buffer)", tlasBytes});
@@ -1074,9 +1141,16 @@ GPUScene::Result GPUSceneImpl::ReserveMesh(FSerializedMesh const& src, GSMesh& o
     outData.meshlets.count = src.dagMeshlets.count;
     outData.meshlets.offset = outOffset + Skip(static_cast<size_t>(src.dagMeshlets.decodedSize));
     outData.meshletVtxOffset = outOffset + Skip(static_cast<size_t>(src.dagMeshletVtx.decodedSize));
-    outData.meshletTriOffset = outOffset + Skip(static_cast<size_t>(src.dagMeshletTri.decodedSize));
     outData.meshletGlobalIndex = mMeshletGlobalCounter;
     mMeshletGlobalCounter += outData.meshlets.count;
+    outData.emissiveMeshlets.count = src.emissiveMeshlets.count;
+    outData.emissiveMeshlets.offset = outOffset + Skip(static_cast<size_t>(src.emissiveMeshlets.decodedSize));
+    outData.emissiveAliases.count = src.emissiveAliases.count;
+    outData.emissiveAliases.offset = outOffset + Skip(static_cast<size_t>(src.emissiveAliases.decodedSize));
+    outData.emissivePrimitiveMap.count = src.emissivePrimitiveMap.count;
+    outData.emissivePrimitiveMap.offset =
+        outOffset + Skip(static_cast<size_t>(src.emissivePrimitiveMap.decodedSize));
+    outData.meshletTriOffset = outOffset + Skip(static_cast<size_t>(src.dagMeshletTri.decodedSize));
     CHECK_MSG(cursor == size, "Mesh layout mismatch: expected {} got {}", size, cursor);
     return Result::InProgress;
 }
@@ -1109,6 +1183,9 @@ size_t GPUSceneImpl::StageMesh(ImmediateUpload::UploadBatch* batch, FSerializedM
     AppendBlobWrite(src.dagMeshlets, header.meshlets.offset);
     AppendBlobWrite(src.dagMeshletVtx, header.meshletVtxOffset);
     AppendBlobWrite(src.dagMeshletTri, header.meshletTriOffset);
+    AppendBlobWrite(src.emissiveMeshlets, header.emissiveMeshlets.offset);
+    AppendBlobWrite(src.emissiveAliases, header.emissiveAliases.offset);
+    AppendBlobWrite(src.emissivePrimitiveMap, header.emissivePrimitiveMap.offset);
     return size;
 }
 
@@ -1248,6 +1325,9 @@ static Pair<FSerializedMesh, Vector<unsigned char>> SerializedFromMesh(FImported
     desc.dagMeshlets = serializer.AppendArray(mesh.dag.meshlets);
     desc.dagMeshletTri = serializer.AppendArray(mesh.dag.meshletTri);
     desc.dagMeshletVtx = serializer.AppendArray(mesh.dag.meshletVtx);
+    desc.emissiveMeshlets = serializer.AppendArray(mesh.dag.emissiveMeshlets);
+    desc.emissiveAliases = serializer.AppendArray(mesh.dag.emissiveAliases);
+    desc.emissivePrimitiveMap = serializer.AppendArray(mesh.dag.emissivePrimitiveMap);
     desc.skinBinding = serializer.AppendArray(mesh.skin);
 
     return {desc, std::move(payload)};
@@ -1340,6 +1420,8 @@ GPUScene::Result GPUSceneImpl::Upload(FBlobDeserializer* blobs, FSerializedMesh 
         g.blas = UINT32_MAX;
         g.offset = offset;
         g.mesh = header;
+        CHECK_MSG(blobs->ReadArray(source.emissiveMeshlets, g.emissiveMeshlets, mAllocator),
+                  "Failed to decode emissive meshlet metadata");
         g.state = ResourceState::Queued;
         g.live = true;
         outHandle = {slot, version};
@@ -1678,6 +1760,9 @@ void GPUSceneImpl::PrepareUploads(UploadBatchState& state)
             IncludeBlob(pending.mesh->dagMeshlets);
             IncludeBlob(pending.mesh->dagMeshletVtx);
             IncludeBlob(pending.mesh->dagMeshletTri);
+            IncludeBlob(pending.mesh->emissiveMeshlets);
+            IncludeBlob(pending.mesh->emissiveAliases);
+            IncludeBlob(pending.mesh->emissivePrimitiveMap);
         }
         else
         {
@@ -3264,6 +3349,7 @@ void GPUSceneImpl::Reset()
     mMaterialBuffer.Reset();
     mInstanceBuffer.Reset();
     mLightBuffer.Reset();
+    mEmissiveClusterBuffer.Reset();
     mLightBVHNodeBuffer.Reset();
     mLightBVHLightIndexBuffer.Reset();
     mLightBVHBitmaskBuffer.Reset();
@@ -3423,6 +3509,7 @@ RHIBuffer* GPUScene::GetDynamicStagingBuffer() const
 RHIBuffer* GPUScene::GetInstanceBuffer() const { return mImpl->mInstanceBuffer.mBuffer.Get(); }
 RHIBuffer* GPUScene::GetMaterialBuffer() const { return mImpl->mMaterialBuffer.mBuffer.Get(); }
 RHIBuffer* GPUScene::GetLightBuffer() const { return mImpl->mLightBuffer.mBuffer.Get(); }
+RHIBuffer* GPUScene::GetEmissiveClusterBuffer() const { return mImpl->mEmissiveClusterBuffer.mBuffer.Get(); }
 RHIBuffer* GPUScene::GetLightBVHNodeBuffer() const { return mImpl->mLightBVHNodeBuffer.mBuffer.Get(); }
 RHIBuffer* GPUScene::GetLightBVHLightIndexBuffer() const { return mImpl->mLightBVHLightIndexBuffer.mBuffer.Get(); }
 RHIBuffer* GPUScene::GetLightBVHBitmaskBuffer() const { return mImpl->mLightBVHBitmaskBuffer.mBuffer.Get(); }

--- a/Source/Renderer/GPUScene.cpp
+++ b/Source/Renderer/GPUScene.cpp
@@ -1554,6 +1554,11 @@ GPUScene::Result GPUSceneImpl::Upload(FTexture const& source, TextureHandle& out
 
 GPUScene::Result GPUSceneImpl::Upload(FImportedMesh const& source, GeometryHandle& outHandle)
 {
+    CHECK_MSG(source.IsQuantized(), "FImportedMesh upload requires quantized vertices");
+    CHECK_MSG(!source.lods.empty() && !source.dag.meshlets.empty(),
+              "FImportedMesh upload requires clustered LOD0 geometry");
+    CHECK_MSG(source.dag.emissivePrimitiveMap.size() == source.lods[0].indices.size() / 3u,
+              "FImportedMesh upload requires emissive meshlet metadata");
     if (source.vertices.empty())
         return Result::InvalidInput;
 

--- a/Source/Renderer/GPUScene.cpp
+++ b/Source/Renderer/GPUScene.cpp
@@ -1422,6 +1422,21 @@ GPUScene::Result GPUSceneImpl::Upload(FBlobDeserializer* blobs, FSerializedMesh 
         g.mesh = header;
         CHECK_MSG(blobs->ReadArray(source.emissiveMeshlets, g.emissiveMeshlets, mAllocator),
                   "Failed to decode emissive meshlet metadata");
+        uint64_t expectedAliasOffset = 0u;
+        for (FEmissiveMeshlet const& emitter : g.emissiveMeshlets)
+        {
+            CHECK_MSG(emitter.meshletIndex < source.dagMeshlets.count, "Emissive meshlet index out of range");
+            CHECK_MSG(emitter.triCount <= kMeshletMaxTriangles, "Emissive meshlet triangle count out of range");
+            CHECK_MSG(emitter.aliasOffset == expectedAliasOffset, "Emissive meshlet aliases are not contiguous");
+            CHECK_MSG(static_cast<uint64_t>(emitter.aliasOffset) + emitter.triCount <= source.emissiveAliases.count,
+                      "Emissive meshlet alias range out of bounds");
+            expectedAliasOffset += emitter.triCount;
+        }
+        CHECK_MSG(expectedAliasOffset == source.emissiveAliases.count, "Emissive alias count mismatch");
+        CHECK_MSG(source.emissiveMeshlets.count == 0u
+                      ? source.emissivePrimitiveMap.count == 0u
+                      : source.emissivePrimitiveMap.count == source.lods[0].indexCount / 3u,
+                  "Emissive primitive map does not match emissive meshlets");
         g.state = ResourceState::Queued;
         g.live = true;
         outHandle = {slot, version};

--- a/Source/Renderer/GPUScene.hpp
+++ b/Source/Renderer/GPUScene.hpp
@@ -33,6 +33,8 @@ inline constexpr uint32_t kGSLightTypePoint = 2u;
 inline constexpr uint32_t kGSLightTypeSpot = 3u;
 inline constexpr uint32_t kGSLightTypeDisk = 4u;
 inline constexpr uint32_t kGSLightTypeRect = 5u;
+inline constexpr uint32_t kLightSelectionClusterBit = 1u << 31u;
+inline constexpr uint32_t kLightSelectionIndexMask = ~kLightSelectionClusterBit;
 
 struct GSOffsetCount
 {
@@ -70,6 +72,9 @@ struct GSMesh
     uint32_t meshletVtxOffset;
     uint32_t meshletTriOffset;
     uint32_t meshletGlobalIndex;
+    GSOffsetCount emissiveMeshlets;
+    GSOffsetCount emissiveAliases;
+    GSOffsetCount emissivePrimitiveMap;
 };
 struct GSInstance
 {
@@ -81,6 +86,7 @@ struct GSInstance
     uint32_t materialIndex{0u}; // In Material buffer (offset)
     uint32_t resourceIndex{UINT32_MAX}; // CPU side resource index, see @ref Geometry
     uint32_t type{kGSInstanceTypeMesh};
+    uint32_t emissiveClusterOffset{UINT32_MAX};
 };
 // XXX: Uber. Super, even. Surely this works for all our needs...
 struct GSMaterial
@@ -134,6 +140,16 @@ struct GSLight
     float3 dpdu; // tangent u-axis (Rect: half-extent u)
     float3 dpdv; // tangent v-axis (Rect: half-extent v)
 };
+struct GSEmissiveCluster
+{
+    uint32_t instanceIndex;
+    uint32_t meshletIndex;
+    uint32_t aliasOffset;
+    uint32_t triCount;
+    float flux;
+    float3 origin;
+    float3 extent;
+};
 struct GSCurveSet
 {
     GSOffsetCount vertices; // FCurveDOTSVertex
@@ -141,10 +157,11 @@ struct GSCurveSet
     GSOffsetCount leaves;   // FCurveLeaf
 };
 #pragma pack(pop)
-static_assert(sizeof(GSMesh) == 44);
-static_assert(sizeof(GSInstance) == 56);
+static_assert(sizeof(GSMesh) == 68);
+static_assert(sizeof(GSInstance) == 60);
 static_assert(sizeof(GSMaterial) == 192);
 static_assert(sizeof(GSLight) == 84);
+static_assert(sizeof(GSEmissiveCluster) == 44);
 static_assert(sizeof(GSCurveSet) == 24);
 static_assert(sizeof(FCurveDOTSVertex) == 8);
 static_assert(sizeof(FCurveLeaf) == 40);
@@ -155,6 +172,7 @@ struct GPUSceneDesc
     uint32_t instanceBudget = static_cast<uint32_t>(1e4); // # of GSInstance elements (ring)
     uint32_t materialBudget = static_cast<uint32_t>(1e3); // # of materials (ring)
     uint32_t lightBudget = static_cast<uint32_t>(1e4); // # of lights (ring)
+    uint32_t emissiveClusterBudget = static_cast<uint32_t>(1e5);
     uint32_t texturesBudget = static_cast<uint32_t>(1e3); // # of textures
     uint32_t geometryBudget = static_cast<uint32_t>(1e4); // # of geometry (ring)
     uint32_t tlasInstanceBudget = static_cast<uint32_t>(1e4); // # of TLAS instances (ring)
@@ -228,6 +246,7 @@ public:
         GSOffsetCount instances;
         GSOffsetCount materials;
         GSOffsetCount lights;
+        GSOffsetCount emissiveClusters;
         struct LightBVH
         {
             uint32_t valid{0u};
@@ -242,6 +261,7 @@ public:
         uint64_t instancesHash{0u};
         uint64_t materialsHash{0u};
         uint64_t lightsHash{0u};
+        uint64_t emissiveClustersHash{0u};
     };
 
     struct GPUSceneTables
@@ -367,6 +387,7 @@ public:
     [[nodiscard]] RHIBuffer* GetInstanceBuffer() const;
     [[nodiscard]] RHIBuffer* GetMaterialBuffer() const;
     [[nodiscard]] RHIBuffer* GetLightBuffer() const;
+    [[nodiscard]] RHIBuffer* GetEmissiveClusterBuffer() const;
     [[nodiscard]] RHIBuffer* GetLightBVHNodeBuffer() const;
     [[nodiscard]] RHIBuffer* GetLightBVHLightIndexBuffer() const;
     [[nodiscard]] RHIBuffer* GetLightBVHBitmaskBuffer() const;

--- a/Source/Renderer/LightBVH.cpp
+++ b/Source/Renderer/LightBVH.cpp
@@ -62,6 +62,7 @@ struct LightSortData
     float cosConeAngle = 1.0f;
     float flux = 0.0f;
     uint32_t lightIndex = ~0u;
+    uint32_t entitySlot = ~0u;
 };
 
 struct BuildingData
@@ -512,7 +513,7 @@ uint32_t buildInternal(LightBVHOptions const& options, SplitFn splitHeuristic, u
     {
         uint32_t globalIndex = data.lightsData[i].lightIndex;
         data.lightIndices.push_back(globalIndex);
-        data.lightBitmasks[globalIndex] = bitmask;
+        data.lightBitmasks[data.lightsData[i].entitySlot] = bitmask;
     }
     return nodeIndex;
 }
@@ -689,17 +690,18 @@ void ComputeAnalyticalLightBounds(GSLight const& light, float3& aabbMin, float3&
     center = float3(0.0f);
 }
 
-LightBVHBuild BuildLightBVH(Span<GSLight const> lights, LightBVHOptions const& options, Allocator* alloc)
+LightBVHBuild BuildLightBVH(Span<GSLight const> lights, Span<GSEmissiveCluster const> clusters,
+                            LightBVHOptions const& options, Allocator* alloc)
 {
     CHECK(alloc);
     LightBVHBuild bvh(alloc);
-    bvh.lightBitmasks.assign(lights.size(), std::numeric_limits<uint64_t>::max());
+    bvh.lightBitmasks.assign(lights.size() + clusters.size(), std::numeric_limits<uint64_t>::max());
 
     CHECK_MSG(options.binCount > 1u, "binCount must be > 1");
 
     BuildingData data(bvh.nodes, alloc);
-    data.lightsData.reserve(lights.size());
-    data.lightIndices.reserve(lights.size());
+    data.lightsData.reserve(lights.size() + clusters.size());
+    data.lightIndices.reserve(lights.size() + clusters.size());
     data.lightBitmasks = bvh.lightBitmasks;
     Vector<GSLightBVHNode> distantNodes(alloc);
     BuildingData distantData(distantNodes, alloc);
@@ -725,6 +727,7 @@ LightBVHBuild BuildLightBVH(Span<GSLight const> lights, LightBVHOptions const& o
                                                   sort.coneDirection, sort.cosConeAngle);
                 sort.flux = proposalWeight;
                 sort.lightIndex = i;
+                sort.entitySlot = i;
                 distantData.lightsData.push_back(sort);
             }
             continue;
@@ -737,6 +740,23 @@ LightBVHBuild BuildLightBVH(Span<GSLight const> lights, LightBVHOptions const& o
                                      sort.coneDirection, sort.cosConeAngle);
         sort.flux = proposalWeight;
         sort.lightIndex = i;
+        sort.entitySlot = i;
+        data.lightsData.push_back(sort);
+    }
+    for (uint32_t i = 0; i < clusters.size(); ++i)
+    {
+        GSEmissiveCluster const& cluster = clusters[i];
+        if (cluster.flux <= 0.0f)
+            continue;
+        LightSortData sort{};
+        sort.bounds.minPoint = cluster.origin - cluster.extent;
+        sort.bounds.maxPoint = cluster.origin + cluster.extent;
+        sort.center = cluster.origin;
+        sort.coneDirection = float3(0.0f);
+        sort.cosConeAngle = kLightBVHInvalidCosConeAngle;
+        sort.flux = cluster.flux;
+        sort.lightIndex = kLightSelectionClusterBit | i;
+        sort.entitySlot = static_cast<uint32_t>(lights.size()) + i;
         data.lightsData.push_back(sort);
     }
 
@@ -782,14 +802,15 @@ LightBVHBuild BuildLightBVH(Span<GSLight const> lights, LightBVHOptions const& o
         bvh.lightIndices.insert(bvh.lightIndices.end(), distantData.lightIndices.begin(),
                                 distantData.lightIndices.end());
         for (LightSortData const& light : distantData.lightsData)
-            bvh.lightBitmasks[light.lightIndex] = distantData.lightBitmasks[light.lightIndex];
+            bvh.lightBitmasks[light.entitySlot] = distantData.lightBitmasks[light.entitySlot];
     }
     bvh.stats.byteSize = static_cast<uint32_t>(bvh.nodes.size() * sizeof(GSLightBVHNode));
     bvh.stats.globalLightCount = static_cast<uint32_t>(distantData.lightsData.size());
     return bvh;
 }
 
-bool ValidateLightBVH(LightBVHBuild const& bvh, Span<GSLight const> lights, String* outError)
+bool ValidateLightBVH(LightBVHBuild const& bvh, Span<GSLight const> lights,
+                      Span<GSEmissiveCluster const> clusters, String* outError)
 {
     auto Fail = [&](char const* message)
     {
@@ -798,7 +819,7 @@ bool ValidateLightBVH(LightBVHBuild const& bvh, Span<GSLight const> lights, Stri
         return false;
     };
 
-    if (bvh.lightBitmasks.size() != lights.size())
+    if (bvh.lightBitmasks.size() != lights.size() + clusters.size())
         return Fail("lightBitmasks size mismatch");
 
     uint32_t expectedDistant = 0;
@@ -812,6 +833,9 @@ bool ValidateLightBVH(LightBVHBuild const& bvh, Span<GSLight const> lights, Stri
         else if (IsFiniteLightType(type) && proposalWeight > 0.0f)
             ++expectedFinite;
     }
+    for (GSEmissiveCluster const& cluster : clusters)
+        if (cluster.flux > 0.0f)
+            ++expectedFinite;
 
     if (!bvh.globalLightIndices.empty())
         return Fail("global light list should be empty");
@@ -825,7 +849,7 @@ bool ValidateLightBVH(LightBVHBuild const& bvh, Span<GSLight const> lights, Stri
         bvh.lightIndices.size() != static_cast<size_t>(expectedFinite + expectedDistant))
         return Fail("BVH light membership mismatch");
 
-    std::vector<uint8_t> covered(lights.size(), 0u);
+    std::vector<uint8_t> covered(lights.size() + clusters.size(), 0u);
     std::stack<Pair<uint32_t, uint32_t>> stack;
     if (bvh.valid)
         stack.push({0u, 0u});
@@ -856,21 +880,31 @@ bool ValidateLightBVH(LightBVHBuild const& bvh, Span<GSLight const> lights, Stri
             for (uint32_t i = 0; i < count; ++i)
             {
                 uint32_t lightIndex = bvh.lightIndices[offset + i];
-                if (lightIndex >= lights.size() || !IsFiniteLightType(GSLightTypeCPU(lights[lightIndex])))
-                    return Fail("leaf contains non-finite light");
-                if (covered[lightIndex])
+                bool isCluster = (lightIndex & kLightSelectionClusterBit) != 0u;
+                uint32_t index = lightIndex & kLightSelectionIndexMask;
+                uint32_t entitySlot = isCluster ? static_cast<uint32_t>(lights.size()) + index : index;
+                if ((!isCluster && (index >= lights.size() || !IsFiniteLightType(GSLightTypeCPU(lights[index])))) ||
+                    (isCluster && index >= clusters.size()))
+                    return Fail("leaf contains invalid finite entity");
+                if (covered[entitySlot])
                     return Fail("duplicate finite light in leaves");
-                covered[lightIndex] = 1u;
+                covered[entitySlot] = 1u;
 
                 float3 childMin, childMax, center, coneDirection;
                 float cosConeAngle = kLightBVHInvalidCosConeAngle;
-                ComputeAnalyticalLightBounds(lights[lightIndex], childMin, childMax, center, coneDirection,
-                                             cosConeAngle);
+                if (isCluster)
+                {
+                    childMin = clusters[index].origin - clusters[index].extent;
+                    childMax = clusters[index].origin + clusters[index].extent;
+                }
+                else
+                    ComputeAnalyticalLightBounds(lights[index], childMin, childMax, center, coneDirection,
+                                                 cosConeAngle);
                 leafBounds |= AABB{childMin, childMax};
-                leafFlux += ComputeLightProposalWeight(lights[lightIndex]);
+                leafFlux += isCluster ? clusters[index].flux : ComputeLightProposalWeight(lights[index]);
 
                 uint32_t replay = 0u;
-                uint64_t bits = bvh.lightBitmasks[lightIndex];
+                uint64_t bits = bvh.lightBitmasks[entitySlot];
                 for (uint32_t d = 0; d < depth; ++d)
                 {
                     if (GSLightBVHNodeIsLeaf(bvh.nodes[replay]))
@@ -905,6 +939,11 @@ bool ValidateLightBVH(LightBVHBuild const& bvh, Span<GSLight const> lights, Stri
         if (IsFiniteLightType(GSLightTypeCPU(lights[i])) && ComputeLightProposalWeight(lights[i]) > 0.0f &&
             !covered[i])
             return Fail("finite light missing from BVH");
+    }
+    for (uint32_t i = 0; i < clusters.size(); ++i)
+    {
+        if (clusters[i].flux > 0.0f && !covered[lights.size() + i])
+            return Fail("emissive cluster missing from BVH");
     }
 
     if (expectedDistant != 0)
@@ -963,4 +1002,26 @@ bool ValidateLightBVH(LightBVHBuild const& bvh, Span<GSLight const> lights, Stri
         }
     }
     return true;
+}
+
+bool LightBVHRunBuilderSelfTests(Allocator* alloc, String* outError)
+{
+    Array<GSLight, 2> lights{};
+    lights[0].flags = kGSLightTypeEnvironment;
+    lights[1].flags = kGSLightTypePoint;
+    lights[1].color = float3(1.0f);
+    lights[1].power = 1.0f;
+    lights[1].position = float3(2.0f, 1.0f, 0.0f);
+    lights[1].params.x = 0.1f;
+
+    Array<GSEmissiveCluster, 2> clusters{};
+    clusters[0].flux = 2.0f;
+    clusters[0].origin = float3(-2.0f, 0.0f, 0.0f);
+    clusters[0].extent = float3(0.5f);
+    clusters[1].flux = 3.0f;
+    clusters[1].origin = float3(0.0f, 2.0f, 0.0f);
+    clusters[1].extent = float3(0.25f);
+
+    LightBVHBuild bvh = BuildLightBVH(lights, clusters, LightBVHOptions{}, alloc);
+    return ValidateLightBVH(bvh, lights, clusters, outError);
 }

--- a/Source/Renderer/LightBVH.hpp
+++ b/Source/Renderer/LightBVH.hpp
@@ -188,8 +188,10 @@ struct LightBVHBuild
 void ComputeAnalyticalLightBounds(GSLight const& light, float3& aabbMin, float3& aabbMax, float3& center,
                                   float3& coneDirection, float& cosConeAngle);
 
-[[nodiscard]] LightBVHBuild BuildLightBVH(Span<GSLight const> lights, LightBVHOptions const& options, Allocator* alloc);
+[[nodiscard]] LightBVHBuild BuildLightBVH(Span<GSLight const> lights, Span<GSEmissiveCluster const> clusters,
+                                          LightBVHOptions const& options, Allocator* alloc);
 
-[[nodiscard]] bool ValidateLightBVH(LightBVHBuild const& bvh, Span<GSLight const> lights, String* outError = nullptr);
+[[nodiscard]] bool ValidateLightBVH(LightBVHBuild const& bvh, Span<GSLight const> lights,
+                                    Span<GSEmissiveCluster const> clusters, String* outError = nullptr);
 
 [[nodiscard]] bool LightBVHRunBuilderSelfTests(Allocator* alloc, String* outError = nullptr);

--- a/Source/Renderer/Mesh.cpp
+++ b/Source/Renderer/Mesh.cpp
@@ -302,6 +302,98 @@ void FImportedMesh::ClusterizeDAG()
         meshlet.coneApex = float3(bounds.cone_apex[0], bounds.cone_apex[1], bounds.cone_apex[2]);
         dag.meshlets.push_back(meshlet);
     }
+
+    struct TriangleKey
+    {
+        uint32_t v[3];
+        bool operator<(TriangleKey const& other) const
+        {
+            if (v[0] != other.v[0])
+                return v[0] < other.v[0];
+            if (v[1] != other.v[1])
+                return v[1] < other.v[1];
+            return v[2] < other.v[2];
+        }
+        bool operator==(TriangleKey const& other) const
+        {
+            return v[0] == other.v[0] && v[1] == other.v[1] && v[2] == other.v[2];
+        }
+    };
+    struct MeshletTriangleRef
+    {
+        TriangleKey key;
+        uint32_t meshletOrdinal;
+        uint32_t localTriangle;
+    };
+    struct PrimitiveRef
+    {
+        TriangleKey key;
+        uint32_t primitive;
+    };
+    auto MakeKey = [](uint32_t a, uint32_t b, uint32_t c)
+    {
+        TriangleKey key{{a, b, c}};
+        std::sort(key.v, key.v + 3);
+        return key;
+    };
+
+    Vector<MeshletTriangleRef> meshletTriangles(vertices.get_allocator().mResource);
+    for (uint32_t meshletIndex = 0; meshletIndex < dag.meshlets.size(); ++meshletIndex)
+    {
+        FMeshlet const& meshlet = dag.meshlets[meshletIndex];
+        if (meshlet.refined != ~0u || meshlet.triCount == 0)
+            continue;
+
+        Vector<float> areas(vertices.get_allocator().mResource);
+        areas.reserve(meshlet.triCount);
+        uint32_t ordinal = static_cast<uint32_t>(dag.emissiveMeshlets.size());
+        float totalArea = 0.0f;
+        for (uint32_t triIndex = 0; triIndex < meshlet.triCount; ++triIndex)
+        {
+            uint32_t localOffset = meshlet.triOffset + triIndex * 3u;
+            uint32_t i0 = dag.meshletVtx[meshlet.vtxOffset + dag.meshletTri[localOffset + 0u]];
+            uint32_t i1 = dag.meshletVtx[meshlet.vtxOffset + dag.meshletTri[localOffset + 1u]];
+            uint32_t i2 = dag.meshletVtx[meshlet.vtxOffset + dag.meshletTri[localOffset + 2u]];
+            float area = 0.5f * length(cross(vertices[i1].position - vertices[i0].position,
+                                             vertices[i2].position - vertices[i0].position));
+            areas.push_back(area);
+            totalArea += area;
+            meshletTriangles.push_back({MakeKey(i0, i1, i2), ordinal, triIndex});
+        }
+
+        AliasTable alias(areas, vertices.get_allocator().mResource);
+        FEmissiveMeshlet& emitter = dag.emissiveMeshlets.emplace_back();
+        emitter.meshletIndex = meshletIndex;
+        emitter.aliasOffset = static_cast<uint32_t>(dag.emissiveAliases.size());
+        emitter.triCount = meshlet.triCount;
+        emitter.area = totalArea;
+        emitter.center = float3(meshlet.centerRadius);
+        emitter.radius = meshlet.centerRadius.w;
+        dag.emissiveAliases.insert(dag.emissiveAliases.end(), alias.mBins.begin(), alias.mBins.end());
+    }
+
+    uint32_t primitiveCount = static_cast<uint32_t>(lods[0].indices.size() / 3u);
+    dag.emissivePrimitiveMap.assign(primitiveCount, ~0u);
+    Vector<PrimitiveRef> primitives(vertices.get_allocator().mResource);
+    primitives.reserve(primitiveCount);
+    for (uint32_t primitive = 0; primitive < primitiveCount; ++primitive)
+    {
+        uint32_t const* tri = lods[0].indices.data() + primitive * 3u;
+        primitives.push_back({MakeKey(tri[0], tri[1], tri[2]), primitive});
+    }
+    std::sort(meshletTriangles.begin(), meshletTriangles.end(),
+              [](MeshletTriangleRef const& a, MeshletTriangleRef const& b) { return a.key < b.key; });
+    std::sort(primitives.begin(), primitives.end(),
+              [](PrimitiveRef const& a, PrimitiveRef const& b) { return a.key < b.key; });
+    CHECK_MSG(meshletTriangles.size() == primitives.size(), "Original meshlets do not cover LOD0 triangles");
+    for (uint32_t i = 0; i < primitives.size(); ++i)
+    {
+        CHECK_MSG(meshletTriangles[i].key == primitives[i].key, "Original meshlet triangle does not match LOD0");
+        CHECK(meshletTriangles[i].meshletOrdinal < (1u << 24u));
+        CHECK(meshletTriangles[i].localTriangle < 256u);
+        dag.emissivePrimitiveMap[primitives[i].primitive] =
+            (meshletTriangles[i].meshletOrdinal << 8u) | meshletTriangles[i].localTriangle;
+    }
     dagClusters = {}; // No longer needed
 }
 size_t FImportedMesh::CalculateQuantizedBound(bool incLod, bool incDag) const

--- a/Source/Renderer/Mesh.hpp
+++ b/Source/Renderer/Mesh.hpp
@@ -2,6 +2,7 @@
 #include <Core/Container.hpp>
 #include <Math/Math.hpp>
 #include "Metadata.hpp"
+#include "Precompute.hpp"
 #include "Serialization.hpp"
 using namespace Foundation;
 using namespace Core;
@@ -84,6 +85,17 @@ struct FMeshlet // @ref meshopt_Meshlet
 };
 static_assert(sizeof(FMeshlet) == 68);
 
+struct FEmissiveMeshlet
+{
+    uint32_t meshletIndex;
+    uint32_t aliasOffset;
+    uint32_t triCount;
+    float area;
+    float3 center;
+    float radius;
+};
+static_assert(sizeof(FEmissiveMeshlet) == 32);
+
 struct FSerializedMeshLOD
 {
     FBlobRef indices;
@@ -101,6 +113,9 @@ struct FSerializedMesh
     FBlobRef dagMeshlets;
     FBlobRef dagMeshletTri;
     FBlobRef dagMeshletVtx;
+    FBlobRef emissiveMeshlets;
+    FBlobRef emissiveAliases;
+    FBlobRef emissivePrimitiveMap;
     FBlobRef skinBinding; // FSkinBinding per vertex; empty when rigid.
     FUUID skeleton{};     // skin skeleton id; kNilUUID when rigid.
 
@@ -127,7 +142,14 @@ struct FImportedMesh
         Vector<FMeshlet> meshlets; // Meshlets built from all clusters
         Vector<uint8_t> meshletTri; // Meshlet local triangle indices
         Vector<uint32_t> meshletVtx; // Meshlet vertex indices into vertices/verticesQuantized
-        DAG(Allocator* alloc) : groups(alloc), meshlets(alloc), meshletTri(alloc), meshletVtx(alloc) {}
+        Vector<FEmissiveMeshlet> emissiveMeshlets;
+        Vector<GSAlias> emissiveAliases;
+        Vector<uint32_t> emissivePrimitiveMap;
+        DAG(Allocator* alloc) :
+            groups(alloc), meshlets(alloc), meshletTri(alloc), meshletVtx(alloc),
+            emissiveMeshlets(alloc), emissiveAliases(alloc), emissivePrimitiveMap(alloc)
+        {
+        }
     } dag;
 
     FImportedMesh(Allocator* alloc);

--- a/Source/Renderer/Precompute.cpp
+++ b/Source/Renderer/Precompute.cpp
@@ -5,6 +5,7 @@
 // Vose
 AliasTable::AliasTable(Span<const float> f, Allocator* alloc) : mBins(f.size(), alloc)
 {
+    CHECK_MSG(!f.empty(), "AliasTable requires at least one weight");
     // Normalize
     const uint n = f.size();
     const double sum = std::accumulate(f.begin(), f.end(), 0.0);
@@ -60,6 +61,43 @@ uint AliasTable::Sample(float u, float& pdf) const
         i = mBins[i].alias;
     pdf = mBins[i].prob;
     return i;
+}
+bool AliasTableRunSelfTests(Allocator* alloc, String* outError)
+{
+    auto Fail = [&](char const* message)
+    {
+        if (outError)
+            *outError = message;
+        return false;
+    };
+    auto Test = [&](Span<const float> values)
+    {
+        AliasTable table(values, alloc);
+        float sum = 0.0f;
+        for (uint32_t i = 0; i < values.size(); ++i)
+            sum += table.PDF(i);
+        if (std::abs(sum - 1.0f) > 1e-5f)
+            return Fail("AliasTable PMF does not sum to one");
+        for (uint32_t i = 0; i < 64u; ++i)
+        {
+            float pdf;
+            uint32_t selected = table.Sample((static_cast<float>(i) + 0.5f) / 64.0f, pdf);
+            if (selected >= values.size() || std::abs(pdf - table.PDF(selected)) > 1e-7f)
+                return false;
+        }
+        return true;
+    };
+    Array<float, 4> uniform{1.0f, 1.0f, 1.0f, 1.0f};
+    Array<float, 4> skewed{1.0f, 2.0f, 4.0f, 8.0f};
+    Array<float, 4> zero{0.0f, 0.0f, 0.0f, 0.0f};
+    if (!Test(uniform) || !Test(skewed) || !Test(zero))
+        return Fail("AliasTable sample/PDF mismatch");
+    Array<float, 1> single{1.0f};
+    AliasTable one(single, alloc);
+    float pdf;
+    if (one.Sample(0.75f, pdf) != 0u || pdf != 1.0f)
+        return Fail("AliasTable single-bin mismatch");
+    return true;
 }
 PiecewiseConstant1D::PiecewiseConstant1D(Span<const float> f, Allocator* alloc) :
     mF(f.begin(), f.end(), alloc), mCDF(f.size(), alloc)

--- a/Source/Renderer/Precompute.hpp
+++ b/Source/Renderer/Precompute.hpp
@@ -12,6 +12,7 @@ struct GSAlias
     float prob, select;
     uint alias;
 };
+static_assert(sizeof(GSAlias) == 12);
 
 struct AliasTable
 {
@@ -21,6 +22,7 @@ struct AliasTable
     uint Sample(float u, float& pdf) const;
     float PDF(uint sample) const { return mBins[sample].prob; }
 };
+[[nodiscard]] bool AliasTableRunSelfTests(Allocator* alloc, String* outError = nullptr);
 // https://www.pbr-book.org/4ed/Sampling_Algorithms/Sampling_1D_Functions#eq:piecewise-step-integral
 struct PiecewiseConstant1D
 {

--- a/Source/Renderer/ProgressivePathtracer.cpp
+++ b/Source/Renderer/ProgressivePathtracer.cpp
@@ -54,6 +54,7 @@ void BuildProgressivePathTracerRenderGraph(Renderer* renderer, RendererUBO* glob
     auto InstanceBuffer = gpu.instanceBuffer;
     auto MaterialBuffer = gpu.materialBuffer;
     auto LightBuffer = gpu.lightBuffer;
+    auto EmissiveClusterBuffer = gpu.emissiveClusterBuffer;
     auto LightBVHNodeBuffer = gpu.lightBVHNodeBuffer;
     auto LightBVHLightIndexBuffer = gpu.lightBVHLightIndexBuffer;
     auto LightBVHBitmaskBuffer = gpu.lightBVHBitmaskBuffer;
@@ -143,6 +144,7 @@ void BuildProgressivePathTracerRenderGraph(Renderer* renderer, RendererUBO* glob
             r->BindBufferStorageRead(self, InstanceBuffer, pipelineStage, "gInstances");
             r->BindBufferStorageRead(self, MaterialBuffer, pipelineStage, "gMaterials");
             r->BindBufferStorageRead(self, LightBuffer, pipelineStage, "gLights");
+            r->BindBufferStorageRead(self, EmissiveClusterBuffer, pipelineStage, "gEmissiveClusters");
             // Sampler
             r->BindBufferStorageRead(self, SobolMatricesBuffer, pipelineStage, "gSobolMatrices");
             r->BindTextureSampler(self, TexSampler, "gTexSampler");

--- a/Source/Renderer/RealtimePathtracer.cpp
+++ b/Source/Renderer/RealtimePathtracer.cpp
@@ -70,6 +70,7 @@ void BuildRealtimePathTracerRenderGraph(Renderer* renderer, RendererUBO* globals
     auto InstanceBuffer = gpu.instanceBuffer;
     auto MaterialBuffer = gpu.materialBuffer;
     auto LightBuffer = gpu.lightBuffer;
+    auto EmissiveClusterBuffer = gpu.emissiveClusterBuffer;
     auto LightBVHNodeBuffer = gpu.lightBVHNodeBuffer;
     auto LightBVHLightIndexBuffer = gpu.lightBVHLightIndexBuffer;
     auto LightBVHBitmaskBuffer = gpu.lightBVHBitmaskBuffer;
@@ -168,6 +169,7 @@ void BuildRealtimePathTracerRenderGraph(Renderer* renderer, RendererUBO* globals
                 r->BindBufferStorageRead(self, InstanceBuffer, stage, "gInstances");
                 r->BindBufferStorageRead(self, MaterialBuffer, stage, "gMaterials");
                 r->BindBufferStorageRead(self, LightBuffer, stage, "gLights");
+                r->BindBufferStorageRead(self, EmissiveClusterBuffer, stage, "gEmissiveClusters");
                 r->BindBufferStorageRead(self, LightBVHNodeBuffer, stage, "lightBVHNodes");
                 r->BindBufferStorageRead(self, LightBVHLightIndexBuffer, stage, "lightBVHLightIndices");
                 r->BindBufferStorageRead(self, LightBVHBitmaskBuffer, stage, "lightBVHBitmasks");
@@ -244,6 +246,7 @@ void BuildRealtimePathTracerRenderGraph(Renderer* renderer, RendererUBO* globals
             r->BindBufferStorageRead(self, InstanceBuffer, pipelineStage, "gInstances");
             r->BindBufferStorageRead(self, MaterialBuffer, pipelineStage, "gMaterials");
             r->BindBufferStorageRead(self, LightBuffer, pipelineStage, "gLights");
+            r->BindBufferStorageRead(self, EmissiveClusterBuffer, pipelineStage, "gEmissiveClusters");
             // Sampler
             r->BindTextureSampler(self, TexSampler, "gTexSampler");
             // Light BVH

--- a/Source/Renderer/Renderer.cpp
+++ b/Source/Renderer/Renderer.cpp
@@ -12,6 +12,8 @@ RendererResources CreateGPUSceneRendererResources(Renderer* renderer, GPUScene* 
         .instanceBuffer = renderer->CreateResource("Instance Buffer", scene->GetInstanceBuffer()),
         .materialBuffer = renderer->CreateResource("Material Buffer", scene->GetMaterialBuffer()),
         .lightBuffer = renderer->CreateResource("Light Buffer", scene->GetLightBuffer()),
+        .emissiveClusterBuffer =
+            renderer->CreateResource("Emissive Cluster Buffer", scene->GetEmissiveClusterBuffer()),
         .lightBVHNodeBuffer = renderer->CreateResource("Light BVH Nodes", scene->GetLightBVHNodeBuffer()),
         .lightBVHLightIndexBuffer =
             renderer->CreateResource("Light BVH Light Indices", scene->GetLightBVHLightIndexBuffer()),

--- a/Source/Renderer/Renderer.hpp
+++ b/Source/Renderer/Renderer.hpp
@@ -65,7 +65,7 @@ struct RendererUBO
     // -- Path Tracing
     uint32_t ptAccumulatedFrames{0u};
     uint32_t ptMaxBounces{4u};
-    float ptFireflyClamp{2.0f}; // 10^x
+    float ptFireflyClamp{1.0f}; // 10^x
     uint32_t ptSamplesPerPixel{1u}; // Always >= 1.
     uint32_t ptPrimaryLightVisibility{0u}; // Analytic lights + sun disks on bounce 0
     float4 sharcPreviousCameraPosition{};

--- a/Source/Renderer/Renderer.hpp
+++ b/Source/Renderer/Renderer.hpp
@@ -54,6 +54,7 @@ struct RendererUBO
     uint32_t matcapTextureIndex{UINT32_MAX};
     // Scene lights
     GSOffsetCount lights{};
+    GSOffsetCount emissiveClusters{};
     GSOffsetCount lightBVHNodes{};
     GSOffsetCount lightBVHLightIndices{};
     uint32_t firstLightBVHBitmask{0u};
@@ -163,6 +164,7 @@ struct RendererResources
     ResourceHandle instanceBuffer{kInvalidHandle};
     ResourceHandle materialBuffer{kInvalidHandle};
     ResourceHandle lightBuffer{kInvalidHandle};
+    ResourceHandle emissiveClusterBuffer{kInvalidHandle};
     ResourceHandle lightBVHNodeBuffer{kInvalidHandle};
     ResourceHandle lightBVHLightIndexBuffer{kInvalidHandle};
     ResourceHandle lightBVHBitmaskBuffer{kInvalidHandle};

--- a/Source/Renderer/Shaders/EPathTracingProgressive.slang
+++ b/Source/Renderer/Shaders/EPathTracingProgressive.slang
@@ -551,7 +551,7 @@ void PathTrace<S : ISampler>(uint2 pix, uint subSample, inout S rng)
             if (!bsdf.IsDirac())
                 AddLocalDirectLighting(hitState, bsdf, wo, localBeta,
                                    bounce, firstBounceCategory, rng, lighting, radiance);
-            if (!AddEmissiveClusterHitEmission(hit.raw, hitState, material, wo, ray.Direction, localBeta,
+            if (!AddEmissiveClusterHitEmission(hit.raw, hitState, ray.Direction, localBeta,
                                                bounce, firstBounceCategory, lastSamplePDF, previousLighting, radiance))
                 AddSurfaceEmissive(material, wo, localBeta, bounce, firstBounceCategory, radiance);
 

--- a/Source/Renderer/Shaders/EPathTracingProgressive.slang
+++ b/Source/Renderer/Shaders/EPathTracingProgressive.slang
@@ -544,11 +544,16 @@ void PathTrace<S : ISampler>(uint2 pix, uint subSample, inout S rng)
         {
             float3 localBeta = beta / pSampleSurface;
             IBSDF bsdf = material.GetSurface();
+            DirectLightingState previousLighting = lighting;
+            lighting.lastLightCtx =
+                LightSampleContext(hitState.position, hitState.geometryNormal, hitState.normal, !bsdf.HasTransmission());
             // Dirac surfaces do not get direct light contribution
             if (!bsdf.IsDirac())
                 AddLocalDirectLighting(hitState, bsdf, wo, localBeta,
                                    bounce, firstBounceCategory, rng, lighting, radiance);
-            AddSurfaceEmissive(material, wo, localBeta, bounce, firstBounceCategory, radiance);
+            if (!AddEmissiveClusterHitEmission(hit.raw, hitState, material, wo, ray.Direction, localBeta,
+                                               bounce, firstBounceCategory, lastSamplePDF, previousLighting, radiance))
+                AddSurfaceEmissive(material, wo, localBeta, bounce, firstBounceCategory, radiance);
 
             AOVCategory sampleCategory;
             BSDFSample sample = BSDF_SampleF(bsdf, wo, rng.sample(), rng.sample2D(),

--- a/Source/Renderer/Shaders/EPathTracingRealtime.slang
+++ b/Source/Renderer/Shaders/EPathTracingRealtime.slang
@@ -321,6 +321,9 @@ void PathTrace<S : ISampler>(uint2 pix, inout S rng)
         PathSample nextSample = PathSample();
         float3 localBeta = beta;
         IBSDF bsdf = material.GetSurface();
+        DirectLightingState previousLighting = lighting;
+        lighting.lastLightCtx =
+            LightSampleContext(hitState.position, hitState.geometryNormal, hitState.normal, !bsdf.HasTransmission());
 
 #if SHARC_QUERY
         if (globalParams.sharcEnabled != 0u && bounce > 0)
@@ -347,8 +350,10 @@ void PathTrace<S : ISampler>(uint2 pix, inout S rng)
         if (!bsdf.IsDirac())
             AddLocalDirectLighting(hitState, bsdf, wo, float3(1.0f),
                                    0u, AOVCategory::Undefined, rng, lighting, localRadiance);
-        AddSurfaceEmissive(
-            material, wo, float3(1.0f), 0u, AOVCategory::Undefined, localRadiance);
+        if (!AddEmissiveClusterHitEmission(hit.raw, hitState, material, wo, ray.Direction, float3(1.0f),
+                                           0u, AOVCategory::Undefined, lastSamplePDF, previousLighting, localRadiance))
+            AddSurfaceEmissive(
+                material, wo, float3(1.0f), 0u, AOVCategory::Undefined, localRadiance);
         SharcHitData sharcHit = MakeSharcHitData(hitState, sharcMaterialDemodulation);
         if (!SharcUpdateHit(
                 sharcParameters, sharcState, sharcHit,
@@ -359,7 +364,9 @@ void PathTrace<S : ISampler>(uint2 pix, inout S rng)
         if (!bsdf.IsDirac())
             AddLocalDirectLighting(hitState, bsdf, wo, localBeta,
                                 bounce, firstBounceCategory, rng, lighting, radiance);
-        AddSurfaceEmissive(material, wo, localBeta, bounce, firstBounceCategory, radiance);
+        if (!AddEmissiveClusterHitEmission(hit.raw, hitState, material, wo, ray.Direction, localBeta,
+                                           bounce, firstBounceCategory, lastSamplePDF, previousLighting, radiance))
+            AddSurfaceEmissive(material, wo, localBeta, bounce, firstBounceCategory, radiance);
 #endif
 
         AOVCategory sampleCategory;

--- a/Source/Renderer/Shaders/EPathTracingRealtime.slang
+++ b/Source/Renderer/Shaders/EPathTracingRealtime.slang
@@ -350,7 +350,7 @@ void PathTrace<S : ISampler>(uint2 pix, inout S rng)
         if (!bsdf.IsDirac())
             AddLocalDirectLighting(hitState, bsdf, wo, float3(1.0f),
                                    0u, AOVCategory::Undefined, rng, lighting, localRadiance);
-        if (!AddEmissiveClusterHitEmission(hit.raw, hitState, material, wo, ray.Direction, float3(1.0f),
+        if (!AddEmissiveClusterHitEmission(hit.raw, hitState, ray.Direction, float3(1.0f),
                                            0u, AOVCategory::Undefined, lastSamplePDF, previousLighting, localRadiance))
             AddSurfaceEmissive(
                 material, wo, float3(1.0f), 0u, AOVCategory::Undefined, localRadiance);
@@ -364,7 +364,7 @@ void PathTrace<S : ISampler>(uint2 pix, inout S rng)
         if (!bsdf.IsDirac())
             AddLocalDirectLighting(hitState, bsdf, wo, localBeta,
                                 bounce, firstBounceCategory, rng, lighting, radiance);
-        if (!AddEmissiveClusterHitEmission(hit.raw, hitState, material, wo, ray.Direction, localBeta,
+        if (!AddEmissiveClusterHitEmission(hit.raw, hitState, ray.Direction, localBeta,
                                            bounce, firstBounceCategory, lastSamplePDF, previousLighting, radiance))
             AddSurfaceEmissive(material, wo, localBeta, bounce, firstBounceCategory, radiance);
 #endif

--- a/Source/Renderer/Shaders/ICommon.slang
+++ b/Source/Renderer/Shaders/ICommon.slang
@@ -83,6 +83,24 @@ public struct GSMesh
     public uint32_t meshletVtxOffset;
     public uint32_t meshletTriOffset;
     public uint32_t meshletGlobalIndex;
+    public GSOffsetCount emissiveMeshlets;
+    public GSOffsetCount emissiveAliases;
+    public GSOffsetCount emissivePrimitiveMap;
+};
+public struct FEmissiveMeshlet
+{
+    public uint32_t meshletIndex;
+    public uint32_t aliasOffset;
+    public uint32_t triCount;
+    public float area;
+    public float3 center;
+    public float radius;
+};
+public struct GSAlias
+{
+    public float prob;
+    public float select;
+    public uint32_t alias;
 };
 public struct MIndex {
     public uint8_t v0;
@@ -98,6 +116,8 @@ public static const uint32_t kGSLightTypePoint = 2u;
 public static const uint32_t kGSLightTypeSpot = 3u;
 public static const uint32_t kGSLightTypeDisk = 4u;
 public static const uint32_t kGSLightTypeRect = 5u;
+public static const uint32_t kLightSelectionClusterBit = 1u << 31u;
+public static const uint32_t kLightSelectionIndexMask = ~kLightSelectionClusterBit;
 public struct GSInstance
 {
     // TRS
@@ -108,6 +128,7 @@ public struct GSInstance
     public uint32_t materialIndex; // In Material buffer (offset)
     public uint32_t resourceIndex; // Debug use
     public uint32_t type; // [7:0] 0=Mesh, 1=Curve; bit 8 = dynamic
+    public uint32_t emissiveClusterOffset;
 };
 // Geometry kind (mesh/curve), ignoring feature flags.
 public uint32_t GSInstanceType(GSInstance i) { return i.type & kGSInstanceTypeMask; }
@@ -210,6 +231,16 @@ public struct GSLight
     public float3 dpdu;         // tangent u-axis (Rect: half-extent u)
     public float3 dpdv;         // tangent v-axis (Rect: half-extent v)
 };
+public struct GSEmissiveCluster
+{
+    public uint32_t instanceIndex;
+    public uint32_t meshletIndex;
+    public uint32_t aliasOffset;
+    public uint32_t triCount;
+    public float flux;
+    public float3 origin;
+    public float3 extent;
+};
 public uint32_t GSLightType(GSLight light) {
     return light.flags & kGSLightTypeMask;
 }
@@ -287,6 +318,7 @@ public struct UBO
     public uint32_t matcapTextureIndex;
     // Scene lights
     public GSOffsetCount lights;
+    public GSOffsetCount emissiveClusters;
     public GSOffsetCount lightBVHNodes;
     public GSOffsetCount lightBVHLightIndices;
     public uint32_t firstLightBVHBitmask;

--- a/Source/Renderer/Shaders/ILight.slang
+++ b/Source/Renderer/Shaders/ILight.slang
@@ -535,9 +535,9 @@ float RectLightSolidAnglePDF(float3 origin, float3 center, float3 dpdu, float3 d
 }
 
 public struct PointLight : ILight {
-    SampledSpectrum I;
-    float3 position;
-    float radius;
+    public SampledSpectrum I;
+    public float3 position;
+    public float radius;
 
     public __init(SampledSpectrum I, float3 position, float radius = 0.0f) {
         this.I = I;
@@ -599,12 +599,12 @@ public struct PointLight : ILight {
 };
 
 public struct SpotLight : ILight {
-    SampledSpectrum I;
-    float3 position;
-    float3 direction;
-    float cosTotalWidth;
-    float cosFalloffStart;
-    float radius;
+    public SampledSpectrum I;
+    public float3 position;
+    public float3 direction;
+    public float cosTotalWidth;
+    public float cosFalloffStart;
+    public float radius;
 
     public __init(SampledSpectrum I, float3 position, float3 direction, float totalWidth, float falloffStart, float radius = 0.0f) {
         this.I = I;
@@ -684,14 +684,14 @@ public struct SpotLight : ILight {
 
 // https://pbr-book.org/4ed/Light_Sources/Area_Lights
 public struct DiskLight : ILight {
-    SampledSpectrum Lemit;
-    float3 position;
-    float3 normal;
-    float3 dpdu;
-    float3 dpdv;
-    float2 radius;
-    float area;
-    bool twoSided;
+    public SampledSpectrum Lemit;
+    public float3 position;
+    public float3 normal;
+    public float3 dpdu;
+    public float3 dpdv;
+    public float2 radius;
+    public float area;
+    public bool twoSided;
 
     public __init(SampledSpectrum Lemit, float3 position, float3 dpdu, float3 dpdv, float2 radius, bool twoSided = false) {
         this.Lemit = Lemit;
@@ -765,13 +765,13 @@ public struct DiskLight : ILight {
 };
 
 public struct RectLight : ILight {
-    SampledSpectrum Lemit;
-    float3 position;
-    float3 normal;
-    float3 dpdu;
-    float3 dpdv;
-    float area;
-    bool twoSided;
+    public SampledSpectrum Lemit;
+    public float3 position;
+    public float3 normal;
+    public float3 dpdu;
+    public float3 dpdv;
+    public float area;
+    public bool twoSided;
 
     public __init(SampledSpectrum Lemit, float3 position, float3 dpdu, float3 dpdv, bool twoSided = false) {
         this.Lemit = Lemit;
@@ -820,13 +820,13 @@ public struct RectLight : ILight {
 };
 
 public struct TriangleLight : ILight {
-    SampledSpectrum Lemit;
-    float3 v0;
-    float3 edge1;
-    float3 edge2;
-    float3 normal;
-    float area;
-    bool twoSided;
+    public SampledSpectrum Lemit;
+    public float3 v0;
+    public float3 edge1;
+    public float3 edge2;
+    public float3 normal;
+    public float area;
+    public bool twoSided;
 
     public __init(SampledSpectrum Lemit, float3 v0, float3 edge1, float3 edge2, bool twoSided = false) {
         this.Lemit = Lemit;

--- a/Source/Renderer/Shaders/ILightBVH.slang
+++ b/Source/Renderer/Shaders/ILightBVH.slang
@@ -17,6 +17,33 @@ GSLight GetLight(uint lightIndex)
     return gLights[GetUBO().lights.offset + lightIndex];
 }
 
+GSEmissiveCluster GetEmissiveCluster(uint clusterIndex)
+{
+    return gEmissiveClusters[GetUBO().emissiveClusters.offset + clusterIndex];
+}
+
+bool IsClusterSelection(uint selection)
+{
+    return (selection & kLightSelectionClusterBit) != 0u;
+}
+
+uint SelectionIndex(uint selection)
+{
+    return selection & kLightSelectionIndexMask;
+}
+
+float ComputeSelectionProposalWeight(uint selection)
+{
+    return IsClusterSelection(selection)
+        ? GetEmissiveCluster(SelectionIndex(selection)).flux
+        : ComputeLightProposalWeight(GetLight(selection));
+}
+
+uint SelectionEntitySlot(uint selection)
+{
+    return IsClusterSelection(selection) ? GetUBO().lights.count + SelectionIndex(selection) : selection;
+}
+
 public struct GSLightBVHNode
 {
     public uint header;
@@ -242,7 +269,7 @@ bool PickLeafLight(uint leafNodeIndex, float u, out float pdf, out uint lightInd
     for (uint i = 0; i < count; ++i)
     {
         uint idx = lightBVHLightIndices[GetUBO().lightBVHLightIndices.offset + offset + i];
-        total += ComputeLightProposalWeight(GetLight(idx));
+        total += ComputeSelectionProposalWeight(idx);
     }
     if (total <= 0.0f)
         return false;
@@ -252,7 +279,7 @@ bool PickLeafLight(uint leafNodeIndex, float u, out float pdf, out uint lightInd
     for (uint i = 0; i < count; ++i)
     {
         uint idx = lightBVHLightIndices[GetUBO().lightBVHLightIndices.offset + offset + i];
-        float weight = ComputeLightProposalWeight(GetLight(idx));
+        float weight = ComputeSelectionProposalWeight(idx);
         cdf += weight;
         if (uScaled < cdf || i + 1u == count)
         {
@@ -274,7 +301,7 @@ float EvalLeafLightPdf(uint leafNodeIndex, uint lightIndex)
     for (uint i = 0; i < count; ++i)
     {
         uint idx = lightBVHLightIndices[GetUBO().lightBVHLightIndices.offset + offset + i];
-        float weight = ComputeLightProposalWeight(GetLight(idx));
+        float weight = ComputeSelectionProposalWeight(idx);
         total += weight;
         if (idx == lightIndex)
             selected = weight;
@@ -284,7 +311,7 @@ float EvalLeafLightPdf(uint leafNodeIndex, uint lightIndex)
 
 float EvalFiniteTraversalPdf(float3 posW, float3 normalW, bool upperHemisphere, uint lightIndex, out uint leafNodeIndex)
 {
-    uint2 bits2 = lightBVHBitmasks[GetUBO().firstLightBVHBitmask + lightIndex];
+    uint2 bits2 = lightBVHBitmasks[GetUBO().firstLightBVHBitmask + SelectionEntitySlot(lightIndex)];
     uint64_t bitmask = ((uint64_t)bits2.y << 32) | bits2.x;
     float pdf = 1.0f;
     leafNodeIndex = GetUBO().lightBVHNodes.offset;
@@ -344,11 +371,14 @@ float EvalDistantTraversalPdf(float3 posW, float3 normalW, bool upperHemisphere,
 
 public float EvalLightSelectionPMF(LightSampleContext ctx, uint lightIndex, bool useUniform)
 {
-    if (GetUBO().lights.count == 0u || lightIndex >= GetUBO().lights.count)
+    uint index = SelectionIndex(lightIndex);
+    bool isCluster = IsClusterSelection(lightIndex);
+    if ((!isCluster && index >= GetUBO().lights.count) ||
+        (isCluster && index >= GetUBO().emissiveClusters.count))
         return 0.0f;
 
     if (useUniform)
-        return 1.0f / float(GetUBO().lights.count);
+        return 1.0f / float(GetUBO().lights.count + GetUBO().emissiveClusters.count);
 
     float3 posW = ctx.p();
     float3 normalW = ctx.ns;
@@ -359,14 +389,13 @@ public float EvalLightSelectionPMF(LightSampleContext ctx, uint lightIndex, bool
     if (total <= 0.0f)
         return 0.0f;
 
-    GSLight gl = GetLight(lightIndex);
-    uint type = GSLightType(gl);
-    if (type == kGSLightTypeDirectional || type == kGSLightTypeEnvironment)
+    uint type = isCluster ? ~0u : GSLightType(GetLight(index));
+    if (!isCluster && (type == kGSLightTypeDirectional || type == kGSLightTypeEnvironment))
     {
         if (distantWeight <= 0.0f || GetUBO().lightBVHDistantNodes.count == 0u)
             return 0.0f;
         uint leafNodeIndex;
-        float traversalPdf = EvalDistantTraversalPdf(posW, normalW, upperHemisphere, lightIndex, leafNodeIndex);
+        float traversalPdf = EvalDistantTraversalPdf(posW, normalW, upperHemisphere, index, leafNodeIndex);
         return (distantWeight / total) * traversalPdf * EvalLeafLightPdf(leafNodeIndex, lightIndex);
     }
 
@@ -385,13 +414,15 @@ public bool SampleLightSelection(LightSampleContext ctx, float u, out uint light
 {
     lightIndex = ~0u;
     selectionPMF = 0.0f;
-    if (GetUBO().lights.count == 0u)
+    if (GetUBO().lights.count + GetUBO().emissiveClusters.count == 0u)
         return false;
 
     if (useUniform)
     {
-        uint n = GetUBO().lights.count;
-        lightIndex = min(uint(u * float(n)), n - 1u);
+        uint analyticCount = GetUBO().lights.count;
+        uint n = analyticCount + GetUBO().emissiveClusters.count;
+        uint entitySlot = min(uint(u * float(n)), n - 1u);
+        lightIndex = entitySlot < analyticCount ? entitySlot : kLightSelectionClusterBit | (entitySlot - analyticCount);
         selectionPMF = 1.0f / float(n);
         return true;
     }

--- a/Source/Renderer/Shaders/IPathTracing.slang
+++ b/Source/Renderer/Shaders/IPathTracing.slang
@@ -818,7 +818,7 @@ uint SampleAliasTable(uint byteOffset, uint count, float u, out float pdf)
     uint binIndex = min(uint(u * float(count)), count - 1u);
     float localU = u * float(count) - float(binIndex);
     GSAlias bin = gPrimBuffer.Load<GSAlias>(byteOffset + binIndex * sizeof(GSAlias));
-    uint selected = localU >= bin.select ? bin.alias : binIndex;
+    uint selected = localU >= bin.select ? min(bin.alias, count - 1u) : binIndex;
     pdf = gPrimBuffer.Load<GSAlias>(byteOffset + selected * sizeof(GSAlias)).prob;
     return selected;
 }
@@ -847,7 +847,7 @@ void LoadEmissiveClusterTriangle(GSEmissiveCluster cluster, uint triangleIndex,
     p2 = inst.rotation.rotate(p2) * inst.scale + inst.transform;
 }
 
-float3 EvaluateClusterEmission(uint instanceIndex, float2 uv)
+float3 EvaluateClusterEmission(uint instanceIndex, float2 uv, float3 wo)
 {
     GSInstance inst = LoadSceneInstance(instanceIndex);
     GSMaterial material = LoadMaterial(inst.materialIndex);
@@ -855,7 +855,17 @@ float3 EvaluateClusterEmission(uint instanceIndex, float2 uv)
     if (material.emissiveTexture != ~0u)
         emission *= gTextures2D[NonUniformResourceIndex(material.emissiveTexture)]
             .SampleLevel(gTexSampler, uv, 0.0f).rgb;
-    return emission;
+    float clearcoat = material.clearcoatFactor;
+    if (material.clearcoatTexture != ~0u)
+        clearcoat *= gTextures2D[NonUniformResourceIndex(material.clearcoatTexture)]
+            .SampleLevel(gTexSampler, uv, 0.0f).r;
+    float clearcoatRoughness = material.clearcoatRoughnessFactor;
+    if (material.clearcoatRoughnessTexture != ~0u)
+        clearcoatRoughness *= gTextures2D[NonUniformResourceIndex(material.clearcoatRoughnessTexture)]
+            .SampleLevel(gTexSampler, uv, 0.0f).g;
+    return emission * CoatEscape(saturate(clearcoat), saturate(clearcoatRoughness), wo,
+                                 globalParams.ggxLutEIndex, globalParams.ggxLutEavgIndex,
+                                 globalParams.energyCompensation != 0u);
 }
 
 LightLiSample SampleEmissiveCluster(uint clusterIndex, LightSampleContext ctx, float aliasU, float2 u)
@@ -875,9 +885,10 @@ LightLiSample SampleEmissiveCluster(uint clusterIndex, LightSampleContext ctx, f
     float b1 = sqrtU * (1.0f - u.y);
     float b2 = sqrtU * u.y;
     float2 uv = uv0 + b1 * (uv1 - uv0) + b2 * (uv2 - uv0);
-    TriangleLight light = TriangleLight(EvaluateClusterEmission(cluster.instanceIndex, uv),
-                                        p0, p1 - p0, p2 - p0, true);
+    TriangleLight light = TriangleLight(float3(1.0f), p0, p1 - p0, p2 - p0, true);
     LightLiSample Li = light.Sample_Li(ctx, u);
+    float3 wo = float3(0.0f, 0.0f, dot(light.normal, -Li.wi));
+    Li.Li = EvaluateClusterEmission(cluster.instanceIndex, uv, wo);
     Li.pdf *= trianglePMF;
     return Li;
 }
@@ -1116,8 +1127,6 @@ void AddSurfaceEmissive(
 bool AddEmissiveClusterHitEmission(
     HitPayload payload,
     HitState hitState,
-    IMaterial material,
-    float3 wo,
     float3 rayDirection,
     float3 beta,
     uint bounce,
@@ -1157,7 +1166,9 @@ bool AddEmissiveClusterHitEmission(
     float mis = (bounce > 0u && lastSamplePDF > EPS)
         ? PowerHeuristic(1, lastSamplePDF, 1, lightPDF)
         : 1.0f;
-    AddRadianceByCategory(radiance, beta * material.Le(wo) * mis,
+    float3 emissionWo = float3(0.0f, 0.0f, dot(light.normal, -rayDirection));
+    float3 emission = EvaluateClusterEmission(payload.instance, hitState.uv, emissionWo);
+    AddRadianceByCategory(radiance, beta * emission * mis,
                           bounce, firstBounceCategory, AOVCategory::Diffuse, bounce == 0u);
     return true;
 }

--- a/Source/Renderer/Shaders/IPathTracing.slang
+++ b/Source/Renderer/Shaders/IPathTracing.slang
@@ -40,6 +40,7 @@ StructuredBuffer<GSMaterial> gMaterials;
 // GPUScene sorts these by type (env, directional, ...see kGSLightType*)
 // gLights[0] always exists and is the environment light.
 StructuredBuffer<GSLight> gLights;
+StructuredBuffer<GSEmissiveCluster> gEmissiveClusters;
 #include "ILightBVH.slang"
 SamplerState gTexSampler;
 
@@ -812,21 +813,98 @@ LightLiSample SampleSceneLight(GSLight gl, LightSampleContext ctx, float2 u)
     }
 }
 
-LightLiSample SampleSceneLight(LightSampleContext ctx, float uc, float2 u)
+uint SampleAliasTable(uint byteOffset, uint count, float u, out float pdf)
+{
+    uint binIndex = min(uint(u * float(count)), count - 1u);
+    float localU = u * float(count) - float(binIndex);
+    GSAlias bin = gPrimBuffer.Load<GSAlias>(byteOffset + binIndex * sizeof(GSAlias));
+    uint selected = localU >= bin.select ? bin.alias : binIndex;
+    pdf = gPrimBuffer.Load<GSAlias>(byteOffset + selected * sizeof(GSAlias)).prob;
+    return selected;
+}
+
+void LoadEmissiveClusterTriangle(GSEmissiveCluster cluster, uint triangleIndex,
+                                 out float3 p0, out float3 p1, out float3 p2,
+                                 out float2 uv0, out float2 uv1, out float2 uv2)
+{
+    GSInstance inst = LoadSceneInstance(cluster.instanceIndex);
+    GSMesh mesh = gPrimBuffer.Load<GSMesh>(inst.resourceOffset);
+    FMeshlet meshlet =
+        gPrimBuffer.Load<FMeshlet>(mesh.meshlets.offset + cluster.meshletIndex * sizeof(FMeshlet));
+    uint triBase = mesh.meshletTriOffset + meshlet.triOffset + triangleIndex * sizeof(MIndex);
+    MIndex tri = gPrimBuffer.Load<MIndex>(triBase);
+    uint vtxBase = mesh.meshletVtxOffset + meshlet.vtxOffset * sizeof(uint32_t);
+    uint i0 = gPrimBuffer.Load<uint32_t>(vtxBase + uint(tri.v0) * sizeof(uint32_t));
+    uint i1 = gPrimBuffer.Load<uint32_t>(vtxBase + uint(tri.v1) * sizeof(uint32_t));
+    uint i2 = gPrimBuffer.Load<uint32_t>(vtxBase + uint(tri.v2) * sizeof(uint32_t));
+    float3 n, t;
+    float sign;
+    FQDecode(gPrimBuffer.Load<FQVertex>(mesh.vertices.offset + i0 * sizeof(FQVertex)), p0, n, t, sign, uv0);
+    FQDecode(gPrimBuffer.Load<FQVertex>(mesh.vertices.offset + i1 * sizeof(FQVertex)), p1, n, t, sign, uv1);
+    FQDecode(gPrimBuffer.Load<FQVertex>(mesh.vertices.offset + i2 * sizeof(FQVertex)), p2, n, t, sign, uv2);
+    p0 = inst.rotation.rotate(p0) * inst.scale + inst.transform;
+    p1 = inst.rotation.rotate(p1) * inst.scale + inst.transform;
+    p2 = inst.rotation.rotate(p2) * inst.scale + inst.transform;
+}
+
+float3 EvaluateClusterEmission(uint instanceIndex, float2 uv)
+{
+    GSInstance inst = LoadSceneInstance(instanceIndex);
+    GSMaterial material = LoadMaterial(inst.materialIndex);
+    float3 emission = material.emissiveFactor;
+    if (material.emissiveTexture != ~0u)
+        emission *= gTextures2D[NonUniformResourceIndex(material.emissiveTexture)]
+            .SampleLevel(gTexSampler, uv, 0.0f).rgb;
+    return emission;
+}
+
+LightLiSample SampleEmissiveCluster(uint clusterIndex, LightSampleContext ctx, float aliasU, float2 u)
+{
+    GSEmissiveCluster cluster = GetEmissiveCluster(clusterIndex);
+    if (cluster.triCount == 0u)
+        return LightLiSample();
+    float trianglePMF;
+    uint triangleIndex = SampleAliasTable(cluster.aliasOffset, cluster.triCount, aliasU, trianglePMF);
+    if (trianglePMF <= 0.0f)
+        return LightLiSample();
+
+    float3 p0, p1, p2;
+    float2 uv0, uv1, uv2;
+    LoadEmissiveClusterTriangle(cluster, triangleIndex, p0, p1, p2, uv0, uv1, uv2);
+    float sqrtU = sqrt(u.x);
+    float b1 = sqrtU * (1.0f - u.y);
+    float b2 = sqrtU * u.y;
+    float2 uv = uv0 + b1 * (uv1 - uv0) + b2 * (uv2 - uv0);
+    TriangleLight light = TriangleLight(EvaluateClusterEmission(cluster.instanceIndex, uv),
+                                        p0, p1 - p0, p2 - p0, true);
+    LightLiSample Li = light.Sample_Li(ctx, u);
+    Li.pdf *= trianglePMF;
+    return Li;
+}
+
+LightLiSample SampleSceneLight(LightSampleContext ctx, float uc, float aliasU, float2 u)
 {
     uint lightIndex;
     float selectionPMF;
     if (!SampleLightSelection(ctx, uc, lightIndex, selectionPMF, (kCompileOptions & uint32_t(PTCompileOptionsBits.LightSamplerUniform)) != 0u))
         return LightLiSample();
 
-    GSLight gl = LoadSceneLight(lightIndex);
-    LightLiSample Li = SampleSceneLight(gl, ctx, u);
+    bool isCluster = IsClusterSelection(lightIndex);
+    GSLight gl = {};
+    LightLiSample Li;
+    if (isCluster)
+        Li = SampleEmissiveCluster(SelectionIndex(lightIndex), ctx, aliasU, u);
+    else
+    {
+        gl = LoadSceneLight(lightIndex);
+        Li = SampleSceneLight(gl, ctx, u);
+    }
     if (Li.pdf > 0.0f)
     {
         SampledSpectrum radiance = Li.Li / (Li.pdf * selectionPMF);
         float mixPDF = Li.isDelta ? Li.pdf : (Li.pdf * selectionPMF);
         return LightLiSample(radiance, Li.wi, mixPDF, Li.isDelta, Li.dist,
-                             GSLightHasFlag(gl, uint32_t(GSLightFlagsBits.UseShadow)));
+                             isCluster || GSLightHasFlag(gl, uint32_t(GSLightFlagsBits.UseShadow)));
     }
     return LightLiSample();
 }
@@ -839,13 +917,16 @@ bool SampleVisibleSceneLight<S : ISampler>(
     out LightLiSample Li)
 {
     ctx = LightSampleContext(hit.position, hit.geometryNormal, hit.normal, upperHemisphere);
-    Li = SampleSceneLight(ctx, rng.sample(), rng.sample2D());
+    Li = SampleSceneLight(ctx, rng.sample(), rng.sample(), rng.sample2D());
     if (Li.pdf <= EPS)
         return false;
 
     float3 shadowNormalFF = dot(Li.wi, hit.geometryNormal) < 0.0f ? -hit.geometryNormal : hit.geometryNormal;
     float3 shadowOrigin = OffsetRay(hit.position, shadowNormalFF);
-    if (Li.useShadow && TraceShadowRay(shadowOrigin, Li.wi, Li.dist, rng))
+    float shadowDistance = Li.dist;
+    if (shadowDistance < INF)
+        shadowDistance = max(EPS_TMin, shadowDistance - max(EPS_TMin, shadowDistance * 1e-4f));
+    if (Li.useShadow && TraceShadowRay(shadowOrigin, Li.wi, shadowDistance, rng))
         Li.pdf = 0.0f;
 
     return Li.pdf > EPS;
@@ -1030,6 +1111,55 @@ void AddSurfaceEmissive(
 {
     AddRadianceByCategory(radiance, beta * material.Le(wo),
                           bounce, firstBounceCategory, AOVCategory::Diffuse, bounce == 0);
+}
+
+bool AddEmissiveClusterHitEmission(
+    HitPayload payload,
+    HitState hitState,
+    IMaterial material,
+    float3 wo,
+    float3 rayDirection,
+    float3 beta,
+    uint bounce,
+    AOVCategory firstBounceCategory,
+    float lastSamplePDF,
+    DirectLightingState lighting,
+    inout PathRadiance radiance)
+{
+    GSInstance inst = LoadSceneInstance(payload.instance);
+    if (inst.emissiveClusterOffset == ~0u || GSInstanceIsDynamic(inst) || GSInstanceType(inst) != kGSInstanceTypeMesh)
+        return false;
+    GSMesh mesh = gPrimBuffer.Load<GSMesh>(inst.resourceOffset);
+    if (payload.primitive >= mesh.emissivePrimitiveMap.count)
+        return false;
+    uint packed = gPrimBuffer.Load<uint32_t>(mesh.emissivePrimitiveMap.offset + payload.primitive * sizeof(uint32_t));
+    if (packed == ~0u)
+        return false;
+    uint meshletOrdinal = packed >> 8u;
+    uint localTriangle = packed & 0xffu;
+    uint clusterIndex = inst.emissiveClusterOffset + meshletOrdinal;
+    if (clusterIndex >= globalParams.emissiveClusters.count)
+        return false;
+    GSEmissiveCluster cluster = GetEmissiveCluster(clusterIndex);
+    if (localTriangle >= cluster.triCount || cluster.flux <= 0.0f)
+        return false;
+
+    float trianglePMF =
+        gPrimBuffer.Load<GSAlias>(cluster.aliasOffset + localTriangle * sizeof(GSAlias)).prob;
+    float3 p0, p1, p2;
+    float2 uv0, uv1, uv2;
+    LoadEmissiveClusterTriangle(cluster, localTriangle, p0, p1, p2, uv0, uv1, uv2);
+    TriangleLight light = TriangleLight(float3(1.0f), p0, p1 - p0, p2 - p0, true);
+    float lightPDF = EvalLightSelectionPMF(
+        lighting.lastLightCtx, kLightSelectionClusterBit | clusterIndex,
+        (kCompileOptions & uint32_t(PTCompileOptionsBits.LightSamplerUniform)) != 0u);
+    lightPDF *= trianglePMF * light.PDF_Li(lighting.lastLightCtx, rayDirection, true);
+    float mis = (bounce > 0u && lastSamplePDF > EPS)
+        ? PowerHeuristic(1, lastSamplePDF, 1, lightPDF)
+        : 1.0f;
+    AddRadianceByCategory(radiance, beta * material.Le(wo) * mis,
+                          bounce, firstBounceCategory, AOVCategory::Diffuse, bounce == 0u);
+    return true;
 }
 
 void WritePrimaryInstanceID(uint2 pix, uint32_t instanceID)


### PR DESCRIPTION
Finally adding these in.

Emissive triangles don't really get their own BLAS, unlike [MPC19](https://fileadmin.cs.lth.se/graphics/research/papers/2019/dyn_manylight/MPC19.pdf). TL;DR - We take surface area to build alias tables - within *meshlet* clusters which we already use for Raster.

Clanker's summarized the weight building process below:

### Triangle alias distribution

For triangle $i$ in meshlet cluster $C$:

$$w_i = A_i^{\mathrm{obj}}$$

$$p(i\mid C) = \frac{w_i}{\sum_{j\in C} w_j} = \frac{A_i^{\mathrm{obj}}}        {\sum_{j\in C} A_j^{\mathrm{obj}}}$$

If the total area is zero:

$$p(i\mid C)=\frac{1}{N_C}$$

### Cluster flux estimate

Mean RGB emission:

$$\bar{L}_e = \frac{\vert{}L_{e,r}\vert{}+\vert{}L_{e,g}\vert{}+\vert{}L_{e,b}\vert{}}{3}$$

Approximate area scaling:

$$ s_A = \max\left( \vert{}s_xs_y\vert{}, \vert{}s_ys_z\vert{}, \vert{}s_zs_x\vert{} \right) $$

For current two-sided emission:

$$ \widehat{\Phi}_C = 2\pi, \bar{L}_e, A_C^{\mathrm{obj}}, s_A $$

where:

$$A_C^{\mathrm{obj}} = \sum_{i\in C} A_i^{\mathrm{obj}}$$

### BVH traversal probabilities

Node importance at shading point $x$:

$$I_N(x) = \frac{ \widehat{\Phi}_N\, C_N(x)\, O_N(x) }{ \max(d_N,r_N)^2 }$$

The probability of selecting the left child is:

$$p(L\mid N,x) = \frac{I_L(x)}      {I_L(x)+I_R(x)}$$

At a leaf:

$$p(C\mid \text{leaf}) = \frac{\widehat{\Phi}_C}      {\sum_{K\in\text{leaf}}\widehat{\Phi}_K}$$

### Complete triangle-light PDF

Once triangle $i$ is selected, a point is sampled uniformly over its world-space area:

$$p_A(y\mid i)=\frac{1}{A_i^{\mathrm{world}}}$$

Converting from area measure to solid angle:

$$p_\omega(y\mid i,x) = \frac{\Vert{}y-x\Vert{}^2}      {A_i^{\mathrm{world}}\,       \vert{}\mathbf n_y\cdot(-\boldsymbol\omega_i)\vert{}}$$

Thus the complete NEE PDF is:

$$p_{\mathrm{NEE}}(\boldsymbol\omega_i) = p_{\mathrm{BVH}}(C\mid x)\, p(i\mid C)\, \frac{\Vert{}y-x\Vert{}^2}      {A_i^{\mathrm{world}}\,       \vert{}\mathbf n_y\cdot(-\boldsymbol\omega_i)\vert{}}$$

Actual emitted radiance is evaluated separately:

$$ L_e(y,\omega) = \mathbf e_{\mathrm{RGB}}, e_{\mathrm{strength}}, T_e(\mathrm{uv}*y), E*{\mathrm{coat}}(\omega) $$

The texture and clearcoat terms affect radiance but currently do not affect the alias or cluster weights.